### PR TITLE
cmd/gb: remove support for -goos -goarch flags

### DIFF
--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -29,8 +29,6 @@ func mustGetwd() string {
 
 var (
 	fs        = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	goos      = fs.String("goos", runtime.GOOS, "override GOOS")
-	goarch    = fs.String("goarch", runtime.GOARCH, "override GOARCH")
 	goroot    = fs.String("goroot", runtime.GOROOT(), "override GOROOT")
 	toolchain = fs.String("toolchain", "gc", "choose go compiler toolchain")
 )
@@ -97,7 +95,7 @@ func main() {
 
 	// must be below fs.Parse because the -q and -v flags will log.Infof
 	project := gb.NewProject(root)
-	tc, err := gb.NewGcToolchain(*goroot, *goos, *goarch)
+	tc, err := gb.NewGcToolchain(*goroot)
 	if err != nil {
 		gb.Fatalf("unable to construct toolchain: %v", err)
 	}

--- a/context.go
+++ b/context.go
@@ -52,6 +52,7 @@ func (c *Context) IncludePaths() []string {
 
 // Pkgdir returns the path to precompiled packages.
 func (c *Context) Pkgdir() string {
+	// TODO(dfc) c.Context.{GOOS,GOARCH} may be out of date wrt. tc.{goos,goarch}
 	return filepath.Join(c.Project.Pkgdir(), c.Context.GOOS, c.Context.GOARCH)
 }
 

--- a/gc.go
+++ b/gc.go
@@ -7,6 +7,7 @@ import (
 	"go/build"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 type gcToolchain struct {
@@ -14,7 +15,9 @@ type gcToolchain struct {
 	gc, cc, ld, as, pack string
 }
 
-func NewGcToolchain(goroot, goos, goarch string) (Toolchain, error) {
+func NewGcToolchain(goroot string) (Toolchain, error) {
+	goos := runtime.GOOS
+	goarch := runtime.GOARCH
 	tooldir := filepath.Join(goroot, "pkg", "tool", goos+"_"+goarch)
 	archchar, err := build.ArchChar(goarch)
 	if err != nil {

--- a/package_test.go
+++ b/package_test.go
@@ -20,7 +20,7 @@ func testProject(t *testing.T) *Project {
 
 func testContext(t *testing.T) *Context {
 	prj := testProject(t)
-	tc, err := NewGcToolchain(runtime.GOROOT(), runtime.GOOS, runtime.GOARCH)
+	tc, err := NewGcToolchain(runtime.GOROOT())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Closes #26

Remove -goos and -goarch flags. They were not being honored and fixing them is quite complicated, so best to remove them for now.