### PR TITLE
[RFC] reduce logging output in the default case

### DIFF
--- a/cmd/gb/build.go
+++ b/cmd/gb/build.go
@@ -48,7 +48,7 @@ var BuildCmd = &Command{
 		ctx.Force = F
 		ctx.SkipInstall = FF
 		defer func() {
-			gb.Infof("build duration: %v %v", time.Since(t0), ctx.Statistics.String())
+			gb.Debugf("build duration: %v %v", time.Since(t0), ctx.Statistics.String())
 		}()
 
 		pkgs, err := resolvePackages(ctx, args...)

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -95,7 +95,7 @@ func main() {
 	}
 	project := gb.NewProject(root)
 
-	gb.Infof("project root %q", project.Projectdir())
+	gb.Debugf("project root %q", project.Projectdir())
 
 	ctx, err := project.NewContext(
 		gb.GcToolchain(gb.Goroot(*goroot)),

--- a/cmd/gb/test.go
+++ b/cmd/gb/test.go
@@ -20,7 +20,7 @@ var TestCmd = &Command{
 		ctx.Force = F
 		ctx.SkipInstall = FF
 		defer func() {
-			gb.Infof("test duration: %v %v", time.Since(t0), ctx.Statistics.String())
+			gb.Debugf("test duration: %v %v", time.Since(t0), ctx.Statistics.String())
 		}()
 
 		pkgs, err := resolvePackagesWithTests(ctx, args...)

--- a/log.go
+++ b/log.go
@@ -3,7 +3,6 @@ package gb
 
 import (
 	"fmt"
-	"log"
 	"os"
 )
 
@@ -13,35 +12,33 @@ var (
 
 	// Verbose enables logging output below INFO
 	Verbose = false
-
-	// Logger is the log.Logger object that backs this logger.
-	Logger = log.New(os.Stdout, "", log.LstdFlags)
 )
 
-var Fatalf = log.Fatalf
-
-func fatalf(format string, args ...interface{}) {
-	Logger.Printf("FATAL "+format, args...)
-	fmt.Scanln()
+func Fatalf(format string, args ...interface{}) {
+	fmt.Printf("FATAL "+format+"\n", args...)
 	os.Exit(1)
 }
 
 func Errorf(format string, args ...interface{}) {
-	Logger.Printf("ERROR "+format, args...)
+	fmt.Printf("ERROR "+format+"\n", args...)
 }
 
 func Warnf(format string, args ...interface{}) {
-	Logger.Printf("WARNING "+format, args...)
+	fmt.Printf("WARNING "+format+"\n", args...)
 }
 
 func Infof(format string, args ...interface{}) {
 	if !Quiet {
-		Logger.Printf("INFO "+format, args...)
+		if Verbose {
+			fmt.Printf("INFO "+format+"\n", args...)
+		} else {
+			fmt.Printf("# "+format+"\n", args...)
+		}
 	}
 }
 
 func Debugf(format string, args ...interface{}) {
 	if Verbose && !Quiet {
-		Logger.Printf("DEBUG "+format, args...)
+		fmt.Printf("DEBUG "+format+"\n", args...)
 	}
 }


### PR DESCRIPTION
Updates #47 

Before:
```
% gb build .../sftp
2015/05/07 21:20:56 INFO project root "/home/dfc/devel/demo"
2015/05/07 21:20:56 INFO compile github.com/kr/fs
2015/05/07 21:20:56 INFO compile golang.org/x/crypto/ssh
2015/05/07 21:20:56 INFO install /home/dfc/devel/demo/pkg/linux/amd64/github.com/kr/fs.a
2015/05/07 21:20:57 INFO install /home/dfc/devel/demo/pkg/linux/amd64/golang.org/x/crypto/ssh.a
2015/05/07 21:20:57 INFO compile github.com/pkg/sftp
2015/05/07 21:20:57 INFO install /home/dfc/devel/demo/pkg/linux/amd64/github.com/pkg/sftp.a
2015/05/07 21:20:57 INFO build duration: 1.823214205s map[compile:1.854594245s]
```

After:
```
% gb build .../sftp                                                                                                                         
# compile github.com/kr/fs
# compile golang.org/x/crypto/ssh
# install /home/dfc/devel/demo/pkg/linux/amd64/github.com/kr/fs.a
# install /home/dfc/devel/demo/pkg/linux/amd64/golang.org/x/crypto/ssh.a
# compile github.com/pkg/sftp
# install /home/dfc/devel/demo/pkg/linux/amd64/github.com/pkg/sftp.a
```

This change reduces the amount of logging in the default case.

`-q` is still not the default, by default `gb` will still produce some output as it runs.

This is a deliberate decision based on watching new gophers use the `go` tool. Generally after replacing their Go install new gophers were confused that their builds suddenly take significantly longer (because the toolchain mismatch defeats incremental compilation). In those cases I wished that `go {build,install}` defaulted to `-v`, hence the motivation for `gb` being more talkative by default.

@wkennedy