### PR TITLE
[RFC] Even less output at the default level

### DIFF
--- a/build.go
+++ b/build.go
@@ -97,7 +97,7 @@ func (g *gc) String() string {
 
 func (g *gc) compile() error {
 	t0 := time.Now()
-	Infof("compile %s", g.pkg.ImportPath)
+	Infof(g.pkg.ImportPath)
 	includes := g.pkg.ctx.IncludePaths()
 	importpath := g.pkg.ImportPath
 	if g.pkg.Scope == "test" && g.pkg.ExtraIncludes != "" {
@@ -152,7 +152,6 @@ func (p *pack) Result() error {
 }
 
 func (p *pack) pack(objs ...ObjTarget) {
-	Debugf("pack [%v]", objs)
 	afiles := make([]string, 0, len(objs))
 	for _, obj := range objs {
 		err := obj.Result()
@@ -200,7 +199,6 @@ func (a *asm) Objfile() string {
 
 func (a *asm) asm() error {
 	t0 := time.Now()
-	Infof("asm %v", a.sfile)
 	err := a.pkg.ctx.tc.Asm(a.pkg.Dir, a.Objfile(), filepath.Join(a.pkg.Dir, a.sfile))
 	a.pkg.ctx.Record("asm", time.Since(t0))
 	return err
@@ -230,7 +228,6 @@ func (l *ld) link() error {
 		return err
 	}
 
-	Infof("link %v", target)
 	includes := l.pkg.ctx.IncludePaths()
 	if l.pkg.Scope == "test" && l.pkg.ExtraIncludes != "" {
 		// TODO(dfc) gross

--- a/gb.go
+++ b/gb.go
@@ -21,8 +21,6 @@ func mktmpdir() string {
 	return d
 }
 
-const debugCopyfile = false
-
 func copyfile(dst, src string) error {
 	err := os.MkdirAll(filepath.Dir(dst), 0755)
 	if err != nil {
@@ -37,9 +35,7 @@ func copyfile(dst, src string) error {
 	if err != nil {
 		return fmt.Errorf("copyfile: create(%q): %v", dst, err)
 	}
-	if debugCopyfile {
-		Debugf("copyfile(dst: %v, src: %v)", dst, src)
-	}
+	Debugf("copyfile(dst: %v, src: %v)", dst, src)
 	_, err = io.Copy(w, r)
 	return err
 }

--- a/install.go
+++ b/install.go
@@ -64,7 +64,6 @@ func (i *install) String() string {
 }
 
 func (i *install) install() error {
-	Infof("install %v", i.dest)
 	return copyfile(i.dest, i.Pkgfile())
 }
 

--- a/log.go
+++ b/log.go
@@ -32,7 +32,7 @@ func Infof(format string, args ...interface{}) {
 		if Verbose {
 			fmt.Printf("INFO "+format+"\n", args...)
 		} else {
-			fmt.Printf("# "+format+"\n", args...)
+			fmt.Printf(format+"\n", args...)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #47 

Thanks for the feedback from #54, this change reduces the output in the success case even further

Before:
```
% gb build -f -R  ~/devel/demo6
# compile github.com/BurntSushi/toml
# compile github.com/hashicorp/consul/api
# compile github.com/kelseyhightower/confd/backends/env
# compile github.com/coreos/go-etcd/etcd
# compile github.com/garyburd/redigo/internal
# compile github.com/samuel/go-zookeeper/zk
# compile github.com/Sirupsen/logrus
# compile github.com/kelseyhightower/memkv
# install /home/dfc/devel/demo6/pkg/linux/amd64/github.com/kelseyhightower/confd/backends/env.a
# install /home/dfc/devel/demo6/pkg/linux/amd64/github.com/garyburd/redigo/internal.a
# compile github.com/garyburd/redigo/redis
# install /home/dfc/devel/demo6/pkg/linux/amd64/github.com/kelseyhightower/memkv.a
# install /home/dfc/devel/demo6/pkg/linux/amd64/github.com/Sirupsen/logrus.a
# compile github.com/kelseyhightower/confd/log
# install /home/dfc/devel/demo6/pkg/linux/amd64/github.com/coreos/go-etcd/etcd.a
# compile github.com/kelseyhightower/confd/backends/etcd
# install /home/dfc/devel/demo6/pkg/linux/amd64/github.com/kelseyhightower/confd/log.a
# install /home/dfc/devel/demo6/pkg/linux/amd64/github.com/BurntSushi/toml.a
# install /home/dfc/devel/demo6/pkg/linux/amd64/github.com/kelseyhightower/confd/backends/etcd.a
# install /home/dfc/devel/demo6/pkg/linux/amd64/github.com/samuel/go-zookeeper/zk.a
# compile github.com/kelseyhightower/confd/backends/zookeeper
# compile github.com/kelseyhightower/confd/integration/zookeeper
# install /home/dfc/devel/demo6/pkg/linux/amd64/github.com/garyburd/redigo/redis.a
# compile github.com/kelseyhightower/confd/backends/redis
# install /home/dfc/devel/demo6/pkg/linux/amd64/github.com/kelseyhightower/confd/backends/zookeeper.a
# link /home/dfc/devel/demo6/bin/zookeeper
# install /home/dfc/devel/demo6/pkg/linux/amd64/github.com/kelseyhightower/confd/backends/redis.a
# install /home/dfc/devel/demo6/pkg/linux/amd64/github.com/hashicorp/consul/api.a
# compile github.com/kelseyhightower/confd/backends/consul
# install /home/dfc/devel/demo6/pkg/linux/amd64/github.com/kelseyhightower/confd/backends/consul.a
# compile github.com/kelseyhightower/confd/backends
# install /home/dfc/devel/demo6/pkg/linux/amd64/github.com/kelseyhightower/confd/backends.a
# compile github.com/kelseyhightower/confd/resource/template
# install /home/dfc/devel/demo6/pkg/linux/amd64/github.com/kelseyhightower/confd/resource/template.a
# compile github.com/kelseyhightower/confd
# link /home/dfc/devel/demo6/bin/confd
```
After
```
% gb build -f -R  ~/devel/demo6
github.com/BurntSushi/toml
github.com/hashicorp/consul/api
github.com/kelseyhightower/confd/backends/env
github.com/coreos/go-etcd/etcd
github.com/garyburd/redigo/internal
github.com/samuel/go-zookeeper/zk
github.com/Sirupsen/logrus
github.com/kelseyhightower/memkv
github.com/garyburd/redigo/redis
github.com/kelseyhightower/confd/log
github.com/kelseyhightower/confd/backends/etcd
github.com/kelseyhightower/confd/backends/zookeeper
github.com/kelseyhightower/confd/integration/zookeeper
github.com/kelseyhightower/confd/backends/redis
github.com/kelseyhightower/confd/backends/consul
github.com/kelseyhightower/confd/backends
github.com/kelseyhightower/confd/resource/template
github.com/kelseyhightower/confd
```
The error case is slightly chjanged, but needs work, which i'll address in #57 

Before:
```
% gb build -R  ~/devel/demo2                                                                     
# compile github.com/juju/juju/provider/gce/google
# compile github.com/juju/juju/worker/uniter/charm
# compile github.com/juju/juju/worker/uniter/relation
# compile gopkg.in/macaroon-bakery.v0/bakery/checkers
# compile github.com/juju/juju/mongo
FATAL command "build" failed: [/home/dfc/go/pkg/tool/linux_amd64/6g -p gopkg.in/macaroon-bakery.v0/bakery/checkers -pack -o /tmp/gb067467488/gopkg.in/macaroon-bakery.v0/bakery/checkers.a -I /tmp/gb067467488 -I /home/dfc/devel/demo2/pkg/linux/amd64 -complete checkers.go declared.go time.go]: exit status 2
declared.go:7: import /home/dfc/devel/demo2/pkg/linux/amd64/gopkg.in/macaroon.v1.a: object is [linux amd64 go1.4.2 X:precisestack] expected [linux amd64 devel +055ecb7 Tue May 5 09:40:07 2015 +0000 X:none]
```
After:
```
% gb build -R  ~/devel/demo2                                                                                            
github.com/juju/juju/provider/gce/google
github.com/juju/juju/worker/uniter/charm
github.com/juju/juju/worker/uniter/relation
gopkg.in/macaroon-bakery.v0/bakery/checkers
github.com/juju/juju/mongo
FATAL command "build" failed: [/home/dfc/go/pkg/tool/linux_amd64/6g -p gopkg.in/macaroon-bakery.v0/bakery/checkers -pack -o /tmp/gb696468934/gopkg.in/macaroon-bakery.v0/bakery/checkers.a -I /tmp/gb696468934 -I /home/dfc/devel/demo2/pkg/linux/amd64 -complete checkers.go declared.go time.go]: exit status 2
declared.go:7: import /home/dfc/devel/demo2/pkg/linux/amd64/gopkg.in/macaroon.v1.a: object is [linux amd64 go1.4.2 X:precisestack] expected [linux amd64 devel +055ecb7 Tue May 5 09:40:07 2015 +0000 X:none]
```

@wkennedy @fatih