### PR TITLE
Always compile .go files related to $PROJECT

### DIFF
--- a/build.go
+++ b/build.go
@@ -104,7 +104,10 @@ func (g *gc) compile() error {
 		// TODO(dfc) gross
 		includes = append([]string{g.pkg.ExtraIncludes}, includes...)
 	}
-	err := g.pkg.ctx.tc.Gc(includes, importpath, g.pkg.Dir, g.Objfile(), g.gofiles, g.pkg.Complete())
+	for i := range g.gofiles {
+		g.gofiles[i], _ = filepath.Rel(g.pkg.ctx.Projectdir(), filepath.Join(g.pkg.Dir, g.gofiles[i]))
+	}
+	err := g.pkg.ctx.tc.Gc(includes, importpath, g.pkg.ctx.Projectdir(), g.Objfile(), g.gofiles, g.pkg.Complete())
 	g.pkg.ctx.Record("compile", time.Since(t0))
 	return err
 }

--- a/gb.go
+++ b/gb.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 func mktmpdir() string {
@@ -51,7 +52,7 @@ func runOut(dir, command string, args ...string) ([]byte, error) {
 	Debugf("cd %s; %s", cmd.Dir, cmd.Args)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		err = fmt.Errorf("%v: %s\n%s", cmd.Args, err, output)
+		fmt.Printf("# %s\n%s", strings.Join(cmd.Args, " "), output)
 	}
 	return output, err
 }


### PR DESCRIPTION
Fixes #57

This PR changes the call to toolchain.Gc to invoke the compiler with its working directory set to `$PROJECT`.

To counter this, files passed to the compiler now include a path relative to `$PROJECT`. This results in error messages relative to `$PROJECT`.

	lucky(~/devel/demo8/src/github.com) % gb build
	github.com/fatih/color/broken
	FATAL command "build" failed: [/home/dfc/go/pkg/tool/linux_amd64/6g -p github.com/fatih/color/broken -pack -o /tmp/gb120635804/github.com/fatih/color/broken.a -I /tmp/gb120635804 -I /home/dfc/devel/demo8/pkg/linux/amd64 -complete src/github.com/fatih/color/broken/color.go]: exit status 2
	src/github.com/fatih/color/broken/color.go:27: non-octal character in escape sequence: b

Compare this to the output from the go tool

     lucky(~/devel/demo8/src/github.com) % gb build -f
     github.com/shiena/ansicolor
     github.com/fatih/color
     github.com/fatih/color/broken
     # /home/dfc/go/pkg/tool/linux_amd64/6g -p github.com/fatih/color/broken -pack -o /tmp/gb286322412/github.com/fatih/color/broken.a -I /tmp/gb286322412 -I /home/dfc/devel/demo8/pkg/linux/amd64 -complete src/github.com/fatih/color/broken/color.go
     src/github.com/fatih/color/broken/color.go:27: non-octal character in escape sequence: b 
     FATAL command "build" failed: exit status 2

/cc @fatih