### PR TITLE
gb-list

### DIFF
--- a/cmd/gb-list/main.go
+++ b/cmd/gb-list/main.go
@@ -21,7 +21,7 @@ func main() {
 		format      string
 		formatStdin bool
 	)
-	flag.StringVar(&projectroot, "R", os.Getenv("GB_PROJECT_ROOT"), "set the project root")
+	flag.StringVar(&projectroot, "R", os.Getenv("GB_PROJECT_DIR"), "set the project root")
 	flag.StringVar(&format, "f", "{{.ImportPath}}\n", "format template")
 	flag.BoolVar(&formatStdin, "s", false, "read format from stdin")
 

--- a/cmd/gb-list/main.go
+++ b/cmd/gb-list/main.go
@@ -58,13 +58,15 @@ func main() {
 	}
 
 	if jsonOutput {
+		views := make([]*PackageView, 0, len(pkgs))
 		for _, pkg := range pkgs {
-			encoded, err := json.MarshalIndent(NewPackageView(pkg), " ", "  ")
-			if err != nil {
-				gb.Fatalf("Error occurred during json encoding: %v", err)
-			}
-			fmt.Println(string(encoded))
+			views = append(views, NewPackageView(pkg))
 		}
+		encoded, err := json.MarshalIndent(views, " ", "  ")
+		if err != nil {
+			gb.Fatalf("Error occurred during json encoding: %v", err)
+		}
+		fmt.Println(string(encoded))
 	} else {
 		tmpl, err := template.New("list").Parse(format)
 		if err != nil {

--- a/cmd/gb-list/main.go
+++ b/cmd/gb-list/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -17,11 +19,19 @@ func main() {
 	var (
 		projectroot string
 		format      string
+		formatStdin bool
 	)
 	flag.StringVar(&projectroot, "R", os.Getenv("GB_PROJECT_ROOT"), "set the project root")
 	flag.StringVar(&format, "f", "{{.ImportPath}}\n", "format template")
+	flag.BoolVar(&formatStdin, "s", false, "read format from stdin")
 
 	flag.Parse()
+
+	if formatStdin {
+		var formatBuffer bytes.Buffer
+		io.Copy(&formatBuffer, os.Stdin)
+		format = formatBuffer.String()
+	}
 
 	tmpl, err := template.New("list").Parse(format)
 	if err != nil {

--- a/cmd/gb-list/main.go
+++ b/cmd/gb-list/main.go
@@ -24,6 +24,7 @@ func main() {
 	flag.StringVar(&projectroot, "R", os.Getenv("GB_PROJECT_DIR"), "set the project root")
 	flag.StringVar(&format, "f", "{{.ImportPath}}\n", "format template")
 	flag.BoolVar(&formatStdin, "s", false, "read format from stdin")
+	flag.BoolVar(&gb.Verbose, "v", false, "verbose")
 
 	flag.Parse()
 

--- a/cmd/gb-list/main.go
+++ b/cmd/gb-list/main.go
@@ -26,7 +26,7 @@ func main() {
 	flag.StringVar(&projectroot, "R", os.Getenv("GB_PROJECT_DIR"), "set the project root")
 	flag.StringVar(&format, "f", "{{.ImportPath}}\n", "format template")
 	flag.BoolVar(&formatStdin, "s", false, "read format from stdin")
-	flag.BoolVar(&gb.Verbose, "v", false, "verbose")
+	flag.BoolVar(&gb.Verbose, "v", gb.Verbose, "enable log levels below INFO level")
 	flag.BoolVar(&jsonOutput, "json", false, "outputs json")
 
 	flag.Parse()

--- a/cmd/gb-list/package_view.go
+++ b/cmd/gb-list/package_view.go
@@ -1,0 +1,27 @@
+package main
+
+import "github.com/constabulary/gb"
+
+type PackageView struct {
+	Dir         string
+	ImportPath  string
+	Name        string
+	Root        string
+	GoFiles     []string
+	Imports     []string
+	TestGoFiles []string
+	TestImports []string
+}
+
+func NewPackageView(pkg *gb.Package) *PackageView {
+	return &PackageView{
+		Dir:         pkg.Dir,
+		ImportPath:  pkg.ImportPath,
+		Name:        pkg.Name,
+		Root:        pkg.Root,
+		GoFiles:     pkg.GoFiles,
+		Imports:     pkg.Package.Imports,
+		TestGoFiles: pkg.TestGoFiles,
+		TestImports: pkg.TestImports,
+	}
+}


### PR DESCRIPTION
Added option to read from stdin. By default, format is `{{.ImportPath}}`, but we can redefine with
`gb list -f "format"` and
`echo "format" | gb list -s`

Connected with #52 