### PR TITLE
Include error

### DIFF
--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -29,7 +29,7 @@ func ResolvePackages(r Resolver, paths ...string) ([]*gb.Package, error) {
 		pkg, err := r.ResolvePackage(path)
 		if err != nil {
 			if _, ok := err.(*build.NoGoError); ok {
-				gb.Debugf("skipping %q", path)
+				gb.Debugf("skipping %q because of error %q", path, err)
 				continue
 			}
 			return pkgs, fmt.Errorf("failed to resolve import path %q: %v", path, err)


### PR DESCRIPTION
I ran across a problem today where I needed this info to understand why
gb wasn't building anything. Turns out it was a misvendored dependency.