### PR TITLE
Test refactor

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -51,3 +51,7 @@ func RunCommand(fs *flag.FlagSet, cmd *Command, projectroot, goroot string, args
 	gb.Debugf("args: %v", args)
 	return cmd.Run(ctx, args)
 }
+
+func mkdir(path string) error {
+	return os.MkdirAll(path, 0755)
+}

--- a/cmd/gb/test.go
+++ b/cmd/gb/test.go
@@ -25,7 +25,7 @@ var TestCmd = &cmd.Command{
 		if err != nil {
 			return err
 		}
-		if err := gb.Test(pkgs...); err != nil {
+		if err := cmd.Test(pkgs...); err != nil {
 			return err
 		}
 		return ctx.Destroy()

--- a/cmd/gotest.go
+++ b/cmd/gotest.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package gb
+package cmd
 
 // imported from $GOROOT/src/cmd/go/test.go
 
@@ -22,10 +22,12 @@ import (
 	"text/template"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/constabulary/gb"
 )
 
 type coverInfo struct {
-	Package *Package
+	Package *gb.Package
 	Vars    map[string]*CoverVar
 }
 
@@ -89,7 +91,7 @@ func loadTestFuncs(ptest *build.Package) (*testFuncs, error) {
 	t := &testFuncs{
 		Package: ptest,
 	}
-	Debugf("loadTestFuncs: %v, %v", ptest.TestGoFiles, ptest.XTestGoFiles)
+	gb.Debugf("loadTestFuncs: %v, %v", ptest.TestGoFiles, ptest.XTestGoFiles)
 	for _, file := range ptest.TestGoFiles {
 		if err := t.load(filepath.Join(ptest.Dir, file), "_test", &t.ImportTest, &t.NeedTest); err != nil {
 			return nil, err

--- a/cmd/resolve_test.go
+++ b/cmd/resolve_test.go
@@ -43,11 +43,10 @@ func testProject(t *testing.T) *gb.Project {
 	return gb.NewProject(root)
 }
 
-func testContext(t *testing.T) *gb.Context {
+func testContext(t *testing.T, opts ...func(*gb.Context) error) *gb.Context {
 	prj := testProject(t)
-	ctx, err := prj.NewContext(
-		gb.GcToolchain(),
-	)
+	opts = append([]func(*gb.Context) error{gb.GcToolchain()}, opts...)
+	ctx, err := prj.NewContext(opts...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestTestPackage(t *testing.T) {
 	gb.Verbose = false
-	defer func() { Verbose = false }()
+	defer func() { gb.Verbose = false }()
 	tests := []struct {
 		pkg     string
-		ldflags []string
+		ldflags string
 		err     error
 	}{
 		{
@@ -38,12 +38,11 @@ func TestTestPackage(t *testing.T) {
 			err: nil,
 		}, {
 			pkg:     "ldflags",
-			ldflags: []string{"-X", "ldflags.gitTagInfo", "banana", "-X", "ldflags.gitRevision", "f7926af2"},
+			ldflags: "-X ldflags.gitTagInfo banana -X ldflags.gitRevision f7926af2",
 		}}
 
 	for _, tt := range tests {
-		ctx := testContext(t)
-		ctx.ldflags = tt.ldflags
+		ctx := testContext(t, gb.Ldflags(tt.ldflags))
 		// TODO(dfc) can we resolve the duplication here ?
 		pkg, err := ctx.ResolvePackageWithTests(tt.pkg)
 		if err != nil {

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -1,12 +1,14 @@
-package gb
+package cmd
 
 import (
 	"testing"
 	"time"
+
+	"github.com/constabulary/gb"
 )
 
 func TestTestPackage(t *testing.T) {
-	Verbose = false
+	gb.Verbose = false
 	defer func() { Verbose = false }()
 	tests := []struct {
 		pkg     string

--- a/target.go
+++ b/target.go
@@ -43,13 +43,13 @@ func (t *target) Result() error {
 }
 
 type ErrTarget struct {
-	error
+	Err error
 }
 
-func (e ErrTarget) Result() error { return e.error }
+func (e ErrTarget) Result() error { return e.Err }
 
 func (e ErrTarget) Pkgfile() string {
-	panic(fmt.Sprintf("PkgFile called on ErrTarget: %v", e.error))
+	panic(fmt.Sprintf("PkgFile called on ErrTarget: %v", e.Err))
 }
 
 // nilTarget always returns nil immediately.


### PR DESCRIPTION
Fixes #102

The ability to build test packages has been moved out of gb, into gb/cmd.
This isn't the best name for the package, but it is consistent with keeping
as much of the shared gb/cmd/gb/ logic out of package main's.