### PR TITLE
runOut: don't lose command output to stdout

### DIFF
--- a/gb.go
+++ b/gb.go
@@ -59,9 +59,9 @@ func run(dir, command string, args ...string) error {
 	var buf bytes.Buffer
 	err := runOut(&buf, dir, command, args...)
 	if err != nil {
-		fmt.Printf("# %s %s\n%s", command, strings.Join(args, " "), buf.String())
+		return fmt.Errorf("# %s %s: %v\n%s", command, strings.Join(args, " "), err, buf.String())
 	}
-	return err
+	return nil
 }
 
 func runOut(output io.Writer, dir, command string, args ...string) error {


### PR DESCRIPTION
Hi,

during my hackish attempt of adding gb to [gin](https://github.com/codegangsta/gin), I noticed that the command output of the `runOut` method is only printed to stdout in the error case.

This means that information and output of the compiler and other commands can't be read by tools using gb by themselfs. This PR adds a simple error type that captures the original error, the command args and their output. 

Ps: see PR codegangsta/gin#73 if you want to play with it.