### PR TITLE
WIP Test binary flag parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+!*
+testdata/bin/

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -21,6 +21,9 @@ type Command struct {
 
 	// AddFlags installs additional flags to be parsed before Run.
 	AddFlags func(fs *flag.FlagSet)
+
+	// Allow plugins to modify arguments
+	FlagParse func(fs *flag.FlagSet, args []string) error
 }
 
 // RunCommand detects the project root, parses flags and runs the Command.

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	fs  = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	cwd string
+	fs   = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	cwd  string
+	args []string
 )
 
 func init() {
@@ -67,9 +68,16 @@ func main() {
 		command.AddFlags(fs)
 	}
 
-	if err := fs.Parse(args[2:]); err != nil {
+	var err error
+	if command.FlagParse != nil {
+		err = command.FlagParse(fs, args)
+	} else {
+		err = fs.Parse(args[2:])
+	}
+	if err != nil {
 		gb.Fatalf("could not parse flags: %v", err)
 	}
+
 	args = fs.Args()              // reset args to the leftovers from fs.Parse
 	cwd, err := filepath.Abs(cwd) // if cwd was passed in via -R, make sure it is absolute
 	if err != nil {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -14,12 +14,12 @@ import (
 // Test returns a Target representing the result of compiling the
 // package pkg, and its dependencies, and linking it with the
 // test runner.
-func Test(pkgs ...*gb.Package) error {
+func Test(flags []string, pkgs ...*gb.Package) error {
 	targets := make(map[string]gb.PkgTarget)
 	roots := make([]gb.Target, 0, len(pkgs))
 	for _, pkg := range pkgs {
 		// commands are built as packages for testing.
-		target := testPackage(targets, pkg)
+		target := testPackage(targets, pkg, flags)
 		roots = append(roots, target)
 	}
 	for _, root := range roots {
@@ -30,7 +30,7 @@ func Test(pkgs ...*gb.Package) error {
 	return nil
 }
 
-func testPackage(targets map[string]gb.PkgTarget, pkg *gb.Package) gb.Target {
+func testPackage(targets map[string]gb.PkgTarget, pkg *gb.Package, flags []string) gb.Target {
 	var gofiles []string
 	gofiles = append(gofiles, pkg.GoFiles...)
 	gofiles = append(gofiles, pkg.TestGoFiles...)
@@ -101,7 +101,7 @@ func testPackage(targets map[string]gb.PkgTarget, pkg *gb.Package) gb.Target {
 	}
 	buildmain := gb.Ld(testmain, gb.Compile(testmain, testobj))
 
-	cmd := exec.Command(testmain.Binfile() + ".test")
+	cmd := exec.Command(testmain.Binfile()+".test", flags...)
 	cmd.Dir = pkg.Dir // tests run in the original source directory
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -11,9 +11,10 @@ func TestTestPackage(t *testing.T) {
 	gb.Verbose = false
 	defer func() { gb.Verbose = false }()
 	tests := []struct {
-		pkg     string
-		ldflags string
-		err     error
+		pkg      string
+		testArgs []string
+		ldflags  string
+		err      error
 	}{
 		{
 			pkg: "a",
@@ -41,6 +42,9 @@ func TestTestPackage(t *testing.T) {
 			ldflags: "-X ldflags.gitTagInfo banana -X ldflags.gitRevision f7926af2",
 		}, {
 			pkg: "cgotest",
+		}, {
+			pkg:      "testflags",
+			testArgs: []string{"-debug"},
 		}}
 
 	for _, tt := range tests {
@@ -51,7 +55,7 @@ func TestTestPackage(t *testing.T) {
 			t.Errorf("ResolvePackage(%v): want %v, got %v", tt.pkg, tt.err, err)
 			continue
 		}
-		if err := Test(pkg); err != tt.err {
+		if err := Test(tt.testArgs, pkg); err != tt.err {
 			t.Errorf("Test(%v): want %v, got %v", tt.pkg, tt.err, err)
 			time.Sleep(500 * time.Millisecond)
 		}

--- a/cmd/testflag.go
+++ b/cmd/testflag.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"flag"
+	"strings"
+)
+
+// TestFlags appends "-test." to flags used with the test plugin to be passed
+// to the test binary.
+func TestFlags(flags *flag.FlagSet, testArgs []string) []string {
+	var targs []string
+	visitor := func(flag *flag.Flag) {
+		if flag.Name == "q" || flag.Name == "v" {
+			targs = append(targs, "-test.v")
+		}
+	}
+	flags.Visit(visitor)
+	targs = append(targs, testArgs...)
+	return targs
+}
+
+// TestExtraFlags is used to separate known arguments from unknown arguments
+// passed on the command line. Returns a string slice of known arguments
+// (parseArgs), and a slice of string arguments for the test binary
+// (extraArgs).
+func TestExtraFlags(flags *flag.FlagSet, args []string) (parseArgs []string, extraArgs []string) {
+	vargs := make(map[string]bool)
+	eargs := make(map[string]bool)
+	keysToSlice := func(m map[string]bool) []string {
+		var s []string
+		for k := range m {
+			s = append(s, k)
+		}
+		return s
+	}
+	visitor := func(flag *flag.Flag) {
+		for _, x := range args {
+			arg := x
+			if strings.HasPrefix(x, "-") {
+				arg = strings.TrimPrefix(x, "-")
+			}
+			if flag.Name == arg {
+				vargs[x] = true
+				break
+			}
+		}
+	}
+	flags.VisitAll(visitor)
+	for _, x := range args {
+		if !strings.HasPrefix(x, "-") {
+			vargs[x] = true
+			continue
+		}
+		if _, ok := vargs[x]; !ok {
+			eargs[x] = true
+		}
+	}
+	return keysToSlice(vargs), keysToSlice(eargs)
+}

--- a/cmd/testflag_test.go
+++ b/cmd/testflag_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"flag"
+	"reflect"
+	"testing"
+)
+
+func TestTestExtraFlags(t *testing.T) {
+	tests := []struct {
+		args    []string // The command line arguments to parse
+		pargs   []string // The expected arguments for flag.Parse
+		eargs   []string // The expected "extra" arguments to pass to the test binary
+		flagSet func() *flag.FlagSet
+		err     error
+	}{
+		{
+			args:  []string{"-q", "-test", "-debug"},
+			pargs: []string{"-q", "-test"},
+			eargs: []string{"-debug"},
+			flagSet: func() *flag.FlagSet {
+				var test, q bool
+				fs := flag.NewFlagSet("test", flag.ExitOnError)
+				fs.BoolVar(&q, "q", false, "quiet")
+				fs.BoolVar(&test, "test", false, "test bool")
+				return fs
+			},
+		}, {
+			args:  []string{"-q", "-debug", "package_name"},
+			pargs: []string{"-q", "package_name"},
+			eargs: []string{"-debug"},
+			flagSet: func() *flag.FlagSet {
+				var q bool
+				fs := flag.NewFlagSet("test", flag.ExitOnError)
+				fs.BoolVar(&q, "q", false, "quiet")
+				return fs
+			},
+		}}
+
+	for _, tt := range tests {
+		pargs, eargs := TestExtraFlags(tt.flagSet(), tt.args)
+		if !reflect.DeepEqual(pargs, tt.pargs) || !reflect.DeepEqual(eargs, tt.eargs) {
+			t.Errorf("TestExtraFlags(%v): want (%v,%v), got (%v,%v)",
+				tt.args, tt.pargs, tt.eargs, pargs, eargs)
+		}
+	}
+}
+
+func TestTestFlags(t *testing.T) {
+	tests := []struct {
+		args    []string // The command line arguments to parse
+		eargs   []string // Extra test binary arguments
+		targs   []string // The expected test binary arguments
+		flagSet func() *flag.FlagSet
+		err     error
+	}{
+		{
+			args:  []string{"-q"},
+			eargs: []string{"-debug"},
+			targs: []string{"-test.v", "-debug"},
+			flagSet: func() *flag.FlagSet {
+				var q bool
+				fs := flag.NewFlagSet("test", flag.ExitOnError)
+				fs.BoolVar(&q, "q", false, "quiet")
+				return fs
+			},
+		}}
+
+	for _, tt := range tests {
+		fs := tt.flagSet()
+		fs.Parse(tt.args)
+		targs := TestFlags(fs, tt.eargs)
+		if !reflect.DeepEqual(targs, tt.targs) {
+			t.Errorf("TestFlags(%v): want %v, got %v", tt.args, tt.targs, targs)
+		}
+	}
+}

--- a/testdata/src/testflags/testflags.go
+++ b/testdata/src/testflags/testflags.go
@@ -1,0 +1,1 @@
+package testflags

--- a/testdata/src/testflags/testflags_test.go
+++ b/testdata/src/testflags/testflags_test.go
@@ -1,0 +1,19 @@
+package testflags
+
+import (
+	"flag"
+	"testing"
+)
+
+var debug bool
+
+func init() {
+	flag.BoolVar(&debug, "debug", false, "Enable debug output.")
+	flag.Parse()
+}
+
+func TestDebug(t *testing.T) {
+	if !debug {
+		t.Error("debug not true!")
+	}
+}


### PR DESCRIPTION
Implements support for passing arguments to the test binary. The
standard arguments, as well as arbitrary arguments.

This is not ready to merge, just want to make it available for review and comment.

- [ ] Arguments
  - [ ] bench
  - [ ] benchmem
  - [ ] benchtime
  - [ ] blockprofile
  - [ ] blockprofilerate
  - [x] cover
  - [ ] covermode
  - [ ] coverpkg
  - [ ] coverprofile
  - [ ] cpu
  - [ ] cpuprofile
  - [ ] memprofile
  - [ ] memprofilerate
  - [ ] outputdir
  - [ ] parallel
  - [ ] run
  - [ ] short
  - [ ] timeout
  - [x] v
  - [x] arbitrary arguments (unlisted)
- [x] Testing
  - [x] TestExtraFlags
  - [x] TestFlags
- [ ] Documentation

Note: only argument parsing of ``-cover`` is implemented but I haven't done anything with building cover support into the test binary.

Also, when testing with ``gb test -v`` all debug output is shown. To only show verbose output, use ``gb test -q``