### PR TITLE
Improved testflag parsing

### DIFF
--- a/cmd/gb/test.go
+++ b/cmd/gb/test.go
@@ -25,8 +25,7 @@ var (
 func addTestFlags(fs *flag.FlagSet) {
 	addBuildFlags(fs)
 	fs.BoolVar(&testCover, "cover", false, "enable coverage analysis")
-	fs.StringVar(&testCoverMode, "covermode", "set",
-		"Set covermode: set (default), count, atomic")
+	fs.StringVar(&testCoverMode, "covermode", "set", "Set covermode: set (default), count, atomic")
 	fs.StringVar(&testCoverPkg, "coverpkg", "", "enable coverage analysis")
 }
 

--- a/cmd/testflag.go
+++ b/cmd/testflag.go
@@ -1,59 +1,175 @@
 package cmd
 
 import (
-	"flag"
+	"errors"
+	"fmt"
+	"strconv"
 	"strings"
 )
 
-// TestFlags appends "-test." to flags used with the test plugin to be passed
-// to the test binary.
-func TestFlags(flags *flag.FlagSet, testArgs []string) []string {
+// testFlagSpec defines a flag we know about.
+type testFlagSpec struct {
+	boolVar    bool // True if the flag is type bool
+	passToTest bool // pass to Test
+	passToAll  bool // pass to test plugin and test binary
+	present    bool // The flag has been seen
+}
+
+// testFlagDefn is the set of flags we process.
+var testFlagDefn = map[string]*testFlagSpec{
+	// local to the test plugin
+	"q":         {boolVar: true, passToAll: true},
+	"v":         {boolVar: true, passToAll: true},
+	"cover":     {boolVar: true},
+	"coverpkg":  {},
+	"covermode": {},
+
+	// Passed to the test binary
+	"bench":            {passToTest: true},
+	"benchmem":         {boolVar: true, passToTest: true},
+	"benchtime":        {passToTest: true},
+	"coverprofile":     {passToTest: true},
+	"cpu":              {passToTest: true},
+	"cpuprofile":       {passToTest: true},
+	"memprofile":       {passToTest: true},
+	"memprofilerate":   {passToTest: true},
+	"blockprofile":     {passToTest: true},
+	"blockprofilerate": {passToTest: true},
+	"outputdir":        {passToTest: true},
+	"parallel":         {passToTest: true},
+	"run":              {passToTest: true},
+	"short":            {boolVar: true, passToTest: true},
+	"timeout":          {passToTest: true},
+}
+
+// TestFlags appends "-test." for flags that are passed to the test binary.
+func TestFlags(testArgs []string) []string {
 	var targs []string
-	visitor := func(flag *flag.Flag) {
-		if flag.Name == "q" || flag.Name == "v" {
-			targs = append(targs, "-test.v")
+	for _, arg := range testArgs {
+		var nArg, nVal, fArg string
+		fArg = arg
+		if !strings.Contains(arg, "-test.") {
+			nArg = strings.TrimPrefix(arg, "-")
+			if strings.Contains(nArg, "=") {
+				nArgVal := strings.Split(nArg, "=")
+				nArg, nVal = nArgVal[0], nArgVal[1]
+			}
+			if val, ok := testFlagDefn[nArg]; ok {
+				// Special handling for -q, needs to be -test.v when passed to the test
+				if nArg == "q" {
+					nArg = "v"
+				}
+				if val.passToTest || val.passToAll {
+					fArg = "-test." + nArg
+				}
+			}
+			if nVal != "" {
+				fArg = fArg + "=" + nVal
+			}
 		}
+		targs = append(targs, fArg)
 	}
-	flags.Visit(visitor)
-	targs = append(targs, testArgs...)
 	return targs
 }
 
-// TestExtraFlags is used to separate known arguments from unknown arguments
-// passed on the command line. Returns a string slice of known arguments
-// (parseArgs), and a slice of string arguments for the test binary
-// (extraArgs).
-func TestExtraFlags(flags *flag.FlagSet, args []string) (parseArgs []string, extraArgs []string) {
-	vargs := make(map[string]bool)
-	eargs := make(map[string]bool)
-	keysToSlice := func(m map[string]bool) []string {
-		var s []string
-		for k := range m {
-			s = append(s, k)
-		}
-		return s
-	}
-	visitor := func(flag *flag.Flag) {
-		for _, x := range args {
-			arg := x
-			if strings.HasPrefix(x, "-") {
-				arg = strings.TrimPrefix(x, "-")
+// TestFlagsExtraParse is used to separate known arguments from unknown
+// arguments passed on the command line. Returns a string slice of test plugin
+// arguments (parseArgs), and a slice of string arguments for the test binary
+// (extraArgs). An error is returned if an argument is used twice, or an
+// argument value is incorrect.
+func TestFlagsExtraParse(args []string) (parseArgs []string, extraArgs []string, err error) {
+	argsLen := len(args)
+
+	for x := 0; x < argsLen; x++ {
+		nArg := args[x]
+		val, ok := testFlagDefn[strings.TrimPrefix(nArg, "-")]
+		if !strings.HasPrefix(nArg, "-") || (ok && !val.passToTest) {
+			err = setArgFound(nArg)
+			if err != nil {
+				return
 			}
-			if flag.Name == arg {
-				vargs[x] = true
-				break
+			parseArgs = append(parseArgs, nArg)
+			if ok && val.passToAll {
+				extraArgs = append(extraArgs, nArg)
 			}
-		}
-	}
-	flags.VisitAll(visitor)
-	for _, x := range args {
-		if !strings.HasPrefix(x, "-") {
-			vargs[x] = true
 			continue
 		}
-		if _, ok := vargs[x]; !ok {
-			eargs[x] = true
+
+		var hadTestPrefix bool
+		hasEqual := strings.Contains(nArg, "=")
+		if !hasEqual && (x+1 < argsLen && !strings.HasPrefix(args[x+1], "-")) {
+			if strings.Contains(nArg, "-test.") {
+				hadTestPrefix = true
+				nArg = strings.TrimPrefix(nArg, "-test.")
+			} else {
+				nArg = strings.TrimPrefix(nArg, "-")
+			}
+			err = setArgFound(nArg)
+			if err != nil {
+				return
+			}
+			// Check the spec for arguments that consume the next argument
+			if val, ok := testFlagDefn[nArg]; ok {
+				if !val.boolVar {
+					nArg = nArg + "=" + args[x+1]
+					x++
+				}
+			}
+		} else if hasEqual {
+			// The argument has an embedded value, here we can do some basic
+			// checking.
+			sArgs := strings.Split(nArg, "=")
+			tArg, tVal := strings.TrimPrefix(sArgs[0], "-"), sArgs[1]
+			if val, ok := testFlagDefn[tArg]; ok {
+				if val.boolVar {
+					if err = checkBoolFlag(tVal); err != nil {
+						return
+					}
+				}
+				if !val.passToTest {
+					parseArgs = append(parseArgs, nArg)
+					continue
+				}
+			}
+		}
+
+		// Append "-" to the argument, and "-test." if "-test." was previously
+		// trimmed.
+		if nArg[0] != '-' {
+			pre := "-"
+			if hadTestPrefix {
+				pre = "-test."
+			}
+			nArg = pre + nArg
+		}
+		extraArgs = append(extraArgs, nArg)
+	}
+
+	return
+}
+
+// setArgFound checks the argument spec to see if arg has already been
+// encountered. If it has, then an error is returned.
+func setArgFound(arg string) error {
+	var err error
+	nArg := strings.TrimPrefix(arg, "-")
+	if val, ok := testFlagDefn[nArg]; ok {
+		if val.present {
+			err = fmt.Errorf("%q flag may be set only once", arg)
+		} else {
+			testFlagDefn[nArg].present = true
 		}
 	}
-	return keysToSlice(vargs), keysToSlice(eargs)
+	return err
+}
+
+// checkBoolFlag checks the value to ensure it is a boolean, if not an error is
+// returned.
+func checkBoolFlag(value string) error {
+	var nErr error
+	_, err := strconv.ParseBool(value)
+	if err != nil {
+		nErr = errors.New("illegal bool flag value " + value)
+	}
+	return nErr
 }

--- a/cmd/testflag_test.go
+++ b/cmd/testflag_test.go
@@ -110,14 +110,10 @@ func TestTestFlagsPreParse(t *testing.T) {
 			}
 		}
 		pargs, eargs, err := TestFlagsExtraParse(tt.args)
-		if tt.err != nil && (err == nil ||
-			(err != nil && tt.err.Error() != err.Error())) {
-			t.Errorf("TestExtraFlags(%v): want err = '%v', got = '%v'",
-				tt.args, tt.err, err)
-		} else if tt.err == nil && (!reflect.DeepEqual(pargs, tt.pargs) ||
-			!reflect.DeepEqual(eargs, tt.eargs)) {
-			t.Errorf("TestExtraFlags(%v): want (%v,%v), got (%v,%v)",
-				tt.args, tt.pargs, tt.eargs, pargs, eargs)
+		if tt.err != nil && (err == nil || (err != nil && tt.err.Error() != err.Error())) {
+			t.Errorf("TestExtraFlags(%v): want err = '%v', got = '%v'", tt.args, tt.err, err)
+		} else if tt.err == nil && (!reflect.DeepEqual(pargs, tt.pargs) || !reflect.DeepEqual(eargs, tt.eargs)) {
+			t.Errorf("TestExtraFlags(%v): want (%v,%v), got (%v,%v)", tt.args, tt.pargs, tt.eargs, pargs, eargs)
 		}
 	}
 }

--- a/cmd/testflag_test.go
+++ b/cmd/testflag_test.go
@@ -1,45 +1,121 @@
 package cmd
 
 import (
-	"flag"
+	"errors"
 	"reflect"
 	"testing"
 )
 
-func TestTestExtraFlags(t *testing.T) {
+func TestTestFlagsPreParse(t *testing.T) {
 	tests := []struct {
-		args    []string // The command line arguments to parse
-		pargs   []string // The expected arguments for flag.Parse
-		eargs   []string // The expected "extra" arguments to pass to the test binary
-		flagSet func() *flag.FlagSet
-		err     error
+		args  []string // The command line arguments to parse
+		pargs []string // The expected arguments for flag.Parse
+		eargs []string // The expected "extra" arguments to pass to the test binary
+		err   error
 	}{
 		{
 			args:  []string{"-q", "-test", "-debug"},
-			pargs: []string{"-q", "-test"},
-			eargs: []string{"-debug"},
-			flagSet: func() *flag.FlagSet {
-				var test, q bool
-				fs := flag.NewFlagSet("test", flag.ExitOnError)
-				fs.BoolVar(&q, "q", false, "quiet")
-				fs.BoolVar(&test, "test", false, "test bool")
-				return fs
-			},
+			pargs: []string{"-q"},
+			eargs: []string{"-q", "-test", "-debug"},
+		}, {
+			args:  []string{"-v", "-debug", "package_name"},
+			pargs: []string{"-v", "package_name"},
+			eargs: []string{"-v", "-debug"},
 		}, {
 			args:  []string{"-q", "-debug", "package_name"},
 			pargs: []string{"-q", "package_name"},
-			eargs: []string{"-debug"},
-			flagSet: func() *flag.FlagSet {
-				var q bool
-				fs := flag.NewFlagSet("test", flag.ExitOnError)
-				fs.BoolVar(&q, "q", false, "quiet")
-				return fs
-			},
+			eargs: []string{"-q", "-debug"},
+		}, {
+			args:  []string{"-bench"},
+			eargs: []string{"-bench"},
+		}, {
+			args:  []string{"-bench=."},
+			eargs: []string{"-bench=."},
+		}, {
+			args:  []string{"-bench", "."},
+			eargs: []string{"-bench=."},
+		}, {
+			args:  []string{"-bench", "Test*"},
+			eargs: []string{"-bench=Test*"},
+		}, {
+			args:  []string{"-benchmem"},
+			eargs: []string{"-benchmem"},
+		}, {
+			args:  []string{"-benchtime", "2s"},
+			eargs: []string{"-benchtime=2s"},
+		}, {
+			args:  []string{"-blockprofile", "profile"},
+			eargs: []string{"-blockprofile=profile"},
+		}, {
+			args:  []string{"-blockprofile", "profile", "-cover"},
+			pargs: []string{"-cover"},
+			eargs: []string{"-blockprofile=profile"},
+		}, {
+			args:  []string{"-blockprofilerate", "2"},
+			eargs: []string{"-blockprofilerate=2"},
+		}, {
+			args:  []string{"-coverprofile", "c.out"},
+			eargs: []string{"-coverprofile=c.out"},
+		}, {
+			args:  []string{"-cpu", "1"},
+			eargs: []string{"-cpu=1"},
+		}, {
+			args:  []string{"-cpu", "1"},
+			eargs: []string{"-cpu=1"},
+		}, {
+			args:  []string{"-timeout"},
+			eargs: []string{"-timeout"},
+		}, {
+			args:  []string{"-timeout", "2s"},
+			eargs: []string{"-timeout=2s"},
+		}, {
+			args:  []string{"-test.run", "test"},
+			eargs: []string{"-test.run=test"},
+		}, {
+			args:  []string{"-test.bench", "Test*"},
+			eargs: []string{"-test.bench=Test*"},
+		}, {
+			args:  []string{"-test.bench=Test*"},
+			eargs: []string{"-test.bench=Test*"},
+		}, {
+			args: []string{"-test.run", "Test*", "-test.run", "Test2*"},
+			err:  errors.New("\"run\" flag may be set only once"),
+		}, {
+			args:  []string{"-cover=true"},
+			pargs: []string{"-cover=true"},
+		}, {
+			args:  []string{"-cover=false"},
+			pargs: []string{"-cover=false"},
+		}, {
+			args: []string{"-cover=notabool"},
+			err:  errors.New("illegal bool flag value notabool"),
+		}, {
+			args: []string{"-run", "Test*", "-run", "Test2*"},
+			err:  errors.New("\"run\" flag may be set only once"),
+		}, {
+			args:  []string{"-short"},
+			eargs: []string{"-short"},
+		}, {
+			args:  []string{"-memprofilerate", "1"},
+			eargs: []string{"-memprofilerate=1"},
+		}, {
+			args:  []string{"-coverpkg", "package"},
+			pargs: []string{"-coverpkg", "package"},
 		}}
 
 	for _, tt := range tests {
-		pargs, eargs := TestExtraFlags(tt.flagSet(), tt.args)
-		if !reflect.DeepEqual(pargs, tt.pargs) || !reflect.DeepEqual(eargs, tt.eargs) {
+		for k, v := range testFlagDefn {
+			if v.present {
+				testFlagDefn[k].present = false
+			}
+		}
+		pargs, eargs, err := TestFlagsExtraParse(tt.args)
+		if tt.err != nil && (err == nil ||
+			(err != nil && tt.err.Error() != err.Error())) {
+			t.Errorf("TestExtraFlags(%v): want err = '%v', got = '%v'",
+				tt.args, tt.err, err)
+		} else if tt.err == nil && (!reflect.DeepEqual(pargs, tt.pargs) ||
+			!reflect.DeepEqual(eargs, tt.eargs)) {
 			t.Errorf("TestExtraFlags(%v): want (%v,%v), got (%v,%v)",
 				tt.args, tt.pargs, tt.eargs, pargs, eargs)
 		}
@@ -48,30 +124,69 @@ func TestTestExtraFlags(t *testing.T) {
 
 func TestTestFlags(t *testing.T) {
 	tests := []struct {
-		args    []string // The command line arguments to parse
-		eargs   []string // Extra test binary arguments
-		targs   []string // The expected test binary arguments
-		flagSet func() *flag.FlagSet
-		err     error
+		eargs []string // Extra test binary arguments
+		targs []string // The expected test binary arguments
 	}{
 		{
-			args:  []string{"-q"},
-			eargs: []string{"-debug"},
+			eargs: []string{"-q", "-debug"},
 			targs: []string{"-test.v", "-debug"},
-			flagSet: func() *flag.FlagSet {
-				var q bool
-				fs := flag.NewFlagSet("test", flag.ExitOnError)
-				fs.BoolVar(&q, "q", false, "quiet")
-				return fs
-			},
+		}, {
+			eargs: []string{"-v", "-debug"},
+			targs: []string{"-test.v", "-debug"},
+		}, {
+			eargs: []string{"-bench"},
+			targs: []string{"-test.bench"},
+		}, {
+			eargs: []string{"-bench", "."},
+			targs: []string{"-test.bench", "."},
+		}, {
+			eargs: []string{"-bench='Test*'"},
+			targs: []string{"-test.bench='Test*'"},
+		}, {
+			eargs: []string{"-benchmem"},
+			targs: []string{"-test.benchmem"},
+		}, {
+			eargs: []string{"-benchtime"},
+			targs: []string{"-test.benchtime"},
+		}, {
+			eargs: []string{"-benchtime", "2s"},
+			targs: []string{"-test.benchtime", "2s"},
+		}, {
+			eargs: []string{"-benchtime=2s"},
+			targs: []string{"-test.benchtime=2s"},
+		}, {
+			eargs: []string{"-blockprofile", "profile"},
+			targs: []string{"-test.blockprofile", "profile"},
+		}, {
+			eargs: []string{"-blockprofile=profile"},
+			targs: []string{"-test.blockprofile=profile"},
+		}, {
+			eargs: []string{"-blockprofile"},
+			targs: []string{"-test.blockprofile"},
+		}, {
+			eargs: []string{"-cpuprofile"},
+			targs: []string{"-test.cpuprofile"},
+		}, {
+			eargs: []string{"-memprofile"},
+			targs: []string{"-test.memprofile"},
+		}, {
+			eargs: []string{"-short"},
+			targs: []string{"-test.short"},
+		}, {
+			eargs: []string{"-memprofilerate", "1"},
+			targs: []string{"-test.memprofilerate", "1"},
+		}, {
+			eargs: []string{"-test.run=test"},
+			targs: []string{"-test.run=test"},
+		}, {
+			eargs: []string{"-test.short"},
+			targs: []string{"-test.short"},
 		}}
 
 	for _, tt := range tests {
-		fs := tt.flagSet()
-		fs.Parse(tt.args)
-		targs := TestFlags(fs, tt.eargs)
+		targs := TestFlags(tt.eargs)
 		if !reflect.DeepEqual(targs, tt.targs) {
-			t.Errorf("TestFlags(%v): want %v, got %v", tt.args, tt.targs, targs)
+			t.Errorf("TestFlags(%v): want %v, got %v", tt.eargs, tt.targs, targs)
 		}
 	}
 }


### PR DESCRIPTION
Last of the testflag stuff.

Copied the flag spec object from the [upstream testflag.go](https://github.com/golang/go/blob/master/src/cmd/go/testflag.go), this removes the need for looping through flag.FlagSet and cleans up the code and tests a bit.

Many more test cases were added.