### PR TITLE
Added support for update and delete in new gb-vendor

### DIFF
--- a/cmd/gb-vendor/delete.go
+++ b/cmd/gb-vendor/delete.go
@@ -44,10 +44,6 @@ var DeleteCmd = &cmd.Command{
 			return fmt.Errorf("dependency could not be deleted: %T %v", err, err)
 		}
 
-		if err := vendor.WriteManifest(manifestFile(ctx), m); err != nil {
-			return err
-		}
-
-		return nil
+		return vendor.WriteManifest(manifestFile(ctx), m)
 	},
 }

--- a/cmd/gb-vendor/delete.go
+++ b/cmd/gb-vendor/delete.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/constabulary/gb"
+	"github.com/constabulary/gb/cmd"
+	"github.com/constabulary/gb/cmd/gb-vendor/vendor"
+)
+
+func init() {
+	registerCommand("delete", DeleteCmd)
+}
+
+var DeleteCmd = &cmd.Command{
+	ShortDesc: "deletes a local dependency",
+	Run: func(ctx *gb.Context, args []string) error {
+		if len(args) != 1 {
+			return fmt.Errorf("delete: import path missing")
+		}
+		path := args[0]
+
+		m, err := vendor.ReadManifest(manifestFile(ctx))
+		if err != nil {
+			return fmt.Errorf("could not load manifest: %T %v", err, err)
+		}
+
+		d, err := m.GetDependencyForImportpath(path)
+		if err != nil {
+			return fmt.Errorf("could not get dependency: %T %v", err, err)
+		}
+
+		err = m.RemoveDependency(d)
+		if err != nil {
+			return fmt.Errorf("dependency could not be deleted: %T %v", err, err)
+		}
+
+		localClone := vendor.GitClone{
+			Path: filepath.Join(ctx.Projectdir(), "vendor", "src", path),
+		}
+		err = localClone.Destroy()
+		if err != nil {
+			return fmt.Errorf("dependency could not be deleted: %T %v", err, err)
+		}
+
+		if err := vendor.WriteManifest(manifestFile(ctx), m); err != nil {
+			return err
+		}
+
+		return nil
+	},
+}

--- a/cmd/gb-vendor/update.go
+++ b/cmd/gb-vendor/update.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/constabulary/gb"
+	"github.com/constabulary/gb/cmd"
+	"github.com/constabulary/gb/cmd/gb-vendor/vendor"
+)
+
+func init() {
+	registerCommand("update", UpdateCmd)
+}
+
+var UpdateCmd = &cmd.Command{
+	ShortDesc: "updates a local dependency",
+	Run: func(ctx *gb.Context, args []string) error {
+		if len(args) != 1 {
+			return fmt.Errorf("update: import path missing")
+		}
+		path := args[0]
+
+		m, err := vendor.ReadManifest(manifestFile(ctx))
+		if err != nil {
+			return fmt.Errorf("could not load manifest: %T %v", err, err)
+		}
+
+		d, err := m.GetDependencyForImportpath(path)
+		if err != nil {
+			return fmt.Errorf("could not update dependency: %T %v", err, err)
+		}
+
+		url := d.Repository
+		err = m.RemoveDependency(d)
+		if err != nil {
+			return fmt.Errorf("dependency could not be deleted: %T %v", err, err)
+		}
+
+		repo := vendor.GitRepo{
+			URL: url,
+		}
+
+		wc, err := repo.Clone()
+		if err != nil {
+			return err
+		}
+
+		rev, err := wc.Revision()
+		if err != nil {
+			return err
+		}
+
+		branch, err := wc.Branch()
+		if err != nil {
+			return err
+		}
+
+		dep := vendor.Dependency{
+			Importpath: path,
+			Repository: url,
+			Revision:   rev,
+			Branch:     branch,
+			Path:       "",
+		}
+
+		if err := m.AddDependency(dep); err != nil {
+			return err
+		}
+
+		dst := filepath.Join(ctx.Projectdir(), "vendor", "src", dep.Importpath)
+		src := filepath.Join(wc.Dir(), dep.Path)
+
+		if err := copypath(dst, src, ".git"); err != nil {
+			return err
+		}
+
+		if err := vendor.WriteManifest(manifestFile(ctx), m); err != nil {
+			return err
+		}
+		return wc.Destroy()
+	},
+}

--- a/cmd/gb-vendor/update.go
+++ b/cmd/gb-vendor/update.go
@@ -28,11 +28,19 @@ var UpdateCmd = &cmd.Command{
 
 		d, err := m.GetDependencyForImportpath(path)
 		if err != nil {
-			return fmt.Errorf("could not update dependency: %T %v", err, err)
+			return fmt.Errorf("could not get dependency: %T %v", err, err)
 		}
 
 		url := d.Repository
 		err = m.RemoveDependency(d)
+		if err != nil {
+			return fmt.Errorf("dependency could not be deleted from manifest: %T %v", err, err)
+		}
+
+		localClone := vendor.GitClone{
+			Path: filepath.Join(ctx.Projectdir(), "vendor", "src", path),
+		}
+		err = localClone.Destroy()
 		if err != nil {
 			return fmt.Errorf("dependency could not be deleted: %T %v", err, err)
 		}

--- a/cmd/gb-vendor/vendor/manifest.go
+++ b/cmd/gb-vendor/vendor/manifest.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 )
 
 // gb-vendor manifest support
@@ -28,6 +29,18 @@ func (m *Manifest) AddDependency(dep Dependency) error {
 	return nil
 }
 
+// RemoveDependency removes a Dependency from the current Manifest
+// If the dependency does not exist then it returns an error
+func (m *Manifest) RemoveDependency(dep Dependency) error {
+	for i, d := range m.Dependencies {
+		if reflect.DeepEqual(d, dep) {
+			m.Dependencies = append(m.Dependencies[:i], m.Dependencies[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("dependency does not exist")
+}
+
 // HasImportpath reports whether the Manifest contains the import path.
 func (m *Manifest) HasImportpath(path string) bool {
 	for _, d := range m.Dependencies {
@@ -36,6 +49,17 @@ func (m *Manifest) HasImportpath(path string) bool {
 		}
 	}
 	return false
+}
+
+// GetDependencyForRepository return a dependency for specified URL
+// If the dependency does not exist it returns an error
+func (m *Manifest) GetDependencyForImportpath(path string) (Dependency, error) {
+	for _, d := range m.Dependencies {
+		if d.Importpath == path {
+			return d, nil
+		}
+	}
+	return Dependency{}, fmt.Errorf("dependency for %s does not exist", path)
 }
 
 // Dependency describes one vendored import path of code


### PR DESCRIPTION
Updates #126

I have added support for update and delete.

There are a lot of possible improvements (automatically detecting unused packages and deleting them with something like `gb vendor delete --unused`, or updating all dependencies `gb vendor update --all`, etc.). If you don't decline the PR (permanently) I will continue with adding other features.

Since the `gb vendor fetch` removes `.git` folder, it is required to remove old copy and clone new one.
I am open for improvements! :)