### PR TITLE
Support for --all, --branch, --revision in gb vendor fetch and --all in gb vendor update

### DIFF
--- a/cmd/gb-vendor/delete.go
+++ b/cmd/gb-vendor/delete.go
@@ -36,7 +36,7 @@ var DeleteCmd = &cmd.Command{
 
 		m, err := vendor.ReadManifest(manifestFile(ctx))
 		if err != nil {
-			return fmt.Errorf("could not load manifest: %T %v", err, err)
+			return fmt.Errorf("could not load manifest: %v", err)
 		}
 
 		var dependencies []vendor.Dependency
@@ -47,7 +47,7 @@ var DeleteCmd = &cmd.Command{
 			p := args[0]
 			dependency, err := m.GetDependencyForImportpath(p)
 			if err != nil {
-				return fmt.Errorf("could not get dependency: %T %v", err, err)
+				return fmt.Errorf("could not get dependency: %v", err)
 			}
 			dependencies = append(dependencies, dependency)
 		}
@@ -56,15 +56,14 @@ var DeleteCmd = &cmd.Command{
 			path := d.Importpath
 
 			if err := m.RemoveDependency(d); err != nil {
-				return fmt.Errorf("dependency could not be deleted: %T %v", err, err)
+				return fmt.Errorf("dependency could not be deleted: %v", err)
 			}
 
 			localClone := vendor.GitClone{
 				Path: filepath.Join(ctx.Projectdir(), "vendor", "src", path),
 			}
-
 			if err := localClone.Destroy(); err != nil {
-				return fmt.Errorf("dependency could not be deleted: %T %v", err, err)
+				return fmt.Errorf("dependency could not be deleted: %v", err)
 			}
 		}
 		return vendor.WriteManifest(manifestFile(ctx), m)

--- a/cmd/gb-vendor/delete.go
+++ b/cmd/gb-vendor/delete.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 func addDeleteFlags(fs *flag.FlagSet) {
-	fs.BoolVar(&deleteAll, "all", false, "update all dependencies")
+	fs.BoolVar(&deleteAll, "all", false, "delete all dependencies")
 }
 
 var DeleteCmd = &cmd.Command{

--- a/cmd/gb-vendor/delete.go
+++ b/cmd/gb-vendor/delete.go
@@ -55,20 +55,15 @@ var DeleteCmd = &cmd.Command{
 		for _, d := range dependencies {
 			path := d.Importpath
 
-			if err != nil {
-				return fmt.Errorf("could not get dependency: %T %v", err, err)
-			}
-
-			err = m.RemoveDependency(d)
-			if err != nil {
+			if err := m.RemoveDependency(d); err != nil {
 				return fmt.Errorf("dependency could not be deleted: %T %v", err, err)
 			}
 
 			localClone := vendor.GitClone{
 				Path: filepath.Join(ctx.Projectdir(), "vendor", "src", path),
 			}
-			err = localClone.Destroy()
-			if err != nil {
+
+			if err := localClone.Destroy(); err != nil {
 				return fmt.Errorf("dependency could not be deleted: %T %v", err, err)
 			}
 		}

--- a/cmd/gb-vendor/fetch.go
+++ b/cmd/gb-vendor/fetch.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"path/filepath"
 
@@ -9,8 +10,23 @@ import (
 	"github.com/constabulary/gb/cmd/gb-vendor/vendor"
 )
 
+var (
+	// gb vendor fetch command flags
+
+	// branch
+	branch string
+
+	// revision (commit)
+	revision string
+)
+
 func init() {
 	registerCommand("fetch", FetchCmd)
+}
+
+func addFetchFlags(fs *flag.FlagSet) {
+	fs.StringVar(&branch, "branch", "master", "branch of the package")
+	fs.StringVar(&revision, "revision", "", "revision of the package")
 }
 
 var FetchCmd = &cmd.Command{
@@ -32,6 +48,19 @@ var FetchCmd = &cmd.Command{
 		}
 
 		wc, err := repo.Clone()
+		if err != nil {
+			return err
+		}
+
+		if branch != "master" && revision != "" {
+			return fmt.Errorf("you cannot specify branch and revision at once")
+		}
+
+		if branch != "master" {
+			err = wc.CheckoutBranch(branch)
+		} else {
+			err = wc.CheckoutRevision(revision)
+		}
 		if err != nil {
 			return err
 		}
@@ -70,4 +99,5 @@ var FetchCmd = &cmd.Command{
 		}
 		return wc.Destroy()
 	},
+	AddFlags: addFetchFlags,
 }

--- a/cmd/gb-vendor/fetch.go
+++ b/cmd/gb-vendor/fetch.go
@@ -39,7 +39,7 @@ var FetchCmd = &cmd.Command{
 
 		m, err := vendor.ReadManifest(manifestFile(ctx))
 		if err != nil {
-			return fmt.Errorf("could not load manifest: %T %v", err, err)
+			return fmt.Errorf("could not load manifest: %v", err)
 		}
 
 		repo, err := vendor.RepositoryFromPath(path)

--- a/cmd/gb-vendor/main.go
+++ b/cmd/gb-vendor/main.go
@@ -23,7 +23,7 @@ func init() {
 	fs.Usage = func() {
 		fmt.Fprintln(os.Stderr, "Usage:")
 		for name, cmd := range commands {
-			fmt.Fprintf(os.Stderr, "  gb %s [flags] [package] - %s\n",
+			fmt.Fprintf(os.Stderr, "  gb vendor %s [flags] [package] - %s\n",
 				name, cmd.ShortDesc)
 		}
 		fmt.Fprintln(os.Stderr)

--- a/cmd/gb-vendor/update.go
+++ b/cmd/gb-vendor/update.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"path/filepath"
-	"flag"
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
@@ -21,14 +21,14 @@ func init() {
 	registerCommand("update", UpdateCmd)
 }
 
-func addUpdateFlags(fs *flag.FlagSet){
+func addUpdateFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&updateAll, "all", false, "update all dependencies")
 }
 
 var UpdateCmd = &cmd.Command{
 	ShortDesc: "updates a local dependency",
 	Run: func(ctx *gb.Context, args []string) error {
-		if len(args) != 1 && !updateAll{
+		if len(args) != 1 && !updateAll {
 			return fmt.Errorf("update: import path or --all flag is missing")
 		} else if len(args) == 1 && updateAll {
 			return fmt.Errorf("update: you cannot specify path and --all flag at once")

--- a/cmd/gb-vendor/update.go
+++ b/cmd/gb-vendor/update.go
@@ -3,89 +3,117 @@ package main
 import (
 	"fmt"
 	"path/filepath"
+	"flag"
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
 	"github.com/constabulary/gb/cmd/gb-vendor/vendor"
 )
 
+var (
+	// gb vendor update flags
+
+	// update all dependencies
+	updateAll bool
+)
+
 func init() {
 	registerCommand("update", UpdateCmd)
+}
+
+func addUpdateFlags(fs *flag.FlagSet){
+	fs.BoolVar(&updateAll, "all", false, "update all dependencies")
 }
 
 var UpdateCmd = &cmd.Command{
 	ShortDesc: "updates a local dependency",
 	Run: func(ctx *gb.Context, args []string) error {
-		if len(args) != 1 {
-			return fmt.Errorf("update: import path missing")
+		if len(args) != 1 && !updateAll{
+			return fmt.Errorf("update: import path or --all flag is missing")
+		} else if len(args) == 1 && updateAll {
+			return fmt.Errorf("update: you cannot specify path and --all flag at once")
 		}
-		path := args[0]
 
 		m, err := vendor.ReadManifest(manifestFile(ctx))
 		if err != nil {
 			return fmt.Errorf("could not load manifest: %T %v", err, err)
 		}
 
-		d, err := m.GetDependencyForImportpath(path)
-		if err != nil {
-			return fmt.Errorf("could not get dependency: %T %v", err, err)
+		var dependencies []vendor.Dependency
+		if updateAll {
+			dependencies = make([]vendor.Dependency, len(m.Dependencies))
+			copy(dependencies, m.Dependencies)
+		} else {
+			p := args[0]
+			dependency, err := m.GetDependencyForImportpath(p)
+			if err != nil {
+				return fmt.Errorf("could not get dependency: %T %v", err, err)
+			}
+			dependencies = append(dependencies, dependency)
 		}
 
-		url := d.Repository
-		err = m.RemoveDependency(d)
-		if err != nil {
-			return fmt.Errorf("dependency could not be deleted from manifest: %T %v", err, err)
+		for _, d := range dependencies {
+			url := d.Repository
+			path := d.Importpath
+
+			err = m.RemoveDependency(d)
+			if err != nil {
+				return fmt.Errorf("dependency could not be deleted from manifest: %T %v", err, err)
+			}
+
+			localClone := vendor.GitClone{
+				Path: filepath.Join(ctx.Projectdir(), "vendor", "src", path),
+			}
+			err = localClone.Destroy()
+			if err != nil {
+				return fmt.Errorf("dependency could not be deleted: %T %v", err, err)
+			}
+
+			repo := vendor.GitRepo{
+				URL: url,
+			}
+
+			wc, err := repo.Clone()
+			if err != nil {
+				return err
+			}
+
+			rev, err := wc.Revision()
+			if err != nil {
+				return err
+			}
+
+			branch, err := wc.Branch()
+			if err != nil {
+				return err
+			}
+
+			dep := vendor.Dependency{
+				Importpath: path,
+				Repository: url,
+				Revision:   rev,
+				Branch:     branch,
+				Path:       "",
+			}
+
+			if err := m.AddDependency(dep); err != nil {
+				return err
+			}
+
+			dst := filepath.Join(ctx.Projectdir(), "vendor", "src", dep.Importpath)
+			src := filepath.Join(wc.Dir(), dep.Path)
+
+			if err := copypath(dst, src); err != nil {
+				return err
+			}
+
+			if err := wc.Destroy(); err != nil {
+				return err
+			}
+			fmt.Println(dependencies)
 		}
 
-		localClone := vendor.GitClone{
-			Path: filepath.Join(ctx.Projectdir(), "vendor", "src", path),
-		}
-		err = localClone.Destroy()
-		if err != nil {
-			return fmt.Errorf("dependency could not be deleted: %T %v", err, err)
-		}
-
-		repo := vendor.GitRepo{
-			URL: url,
-		}
-
-		wc, err := repo.Clone()
-		if err != nil {
-			return err
-		}
-
-		rev, err := wc.Revision()
-		if err != nil {
-			return err
-		}
-
-		branch, err := wc.Branch()
-		if err != nil {
-			return err
-		}
-
-		dep := vendor.Dependency{
-			Importpath: path,
-			Repository: url,
-			Revision:   rev,
-			Branch:     branch,
-			Path:       "",
-		}
-
-		if err := m.AddDependency(dep); err != nil {
-			return err
-		}
-
-		dst := filepath.Join(ctx.Projectdir(), "vendor", "src", dep.Importpath)
-		src := filepath.Join(wc.Dir(), dep.Path)
-
-		if err := copypath(dst, src); err != nil {
-			return err
-		}
-
-		if err := vendor.WriteManifest(manifestFile(ctx), m); err != nil {
-			return err
-		}
-		return wc.Destroy()
+		return vendor.WriteManifest(manifestFile(ctx), m)
 	},
+	AddFlags: addUpdateFlags,
 }

--- a/cmd/gb-vendor/update.go
+++ b/cmd/gb-vendor/update.go
@@ -36,7 +36,7 @@ var UpdateCmd = &cmd.Command{
 
 		m, err := vendor.ReadManifest(manifestFile(ctx))
 		if err != nil {
-			return fmt.Errorf("could not load manifest: %T %v", err, err)
+			return fmt.Errorf("could not load manifest: %v", err)
 		}
 
 		var dependencies []vendor.Dependency
@@ -47,7 +47,7 @@ var UpdateCmd = &cmd.Command{
 			p := args[0]
 			dependency, err := m.GetDependencyForImportpath(p)
 			if err != nil {
-				return fmt.Errorf("could not get dependency: %T %v", err, err)
+				return fmt.Errorf("could not get dependency: %v", err)
 			}
 			dependencies = append(dependencies, dependency)
 		}
@@ -58,7 +58,7 @@ var UpdateCmd = &cmd.Command{
 
 			err = m.RemoveDependency(d)
 			if err != nil {
-				return fmt.Errorf("dependency could not be deleted from manifest: %T %v", err, err)
+				return fmt.Errorf("dependency could not be deleted from manifest: %v", err)
 			}
 
 			localClone := vendor.GitClone{
@@ -66,7 +66,7 @@ var UpdateCmd = &cmd.Command{
 			}
 			err = localClone.Destroy()
 			if err != nil {
-				return fmt.Errorf("dependency could not be deleted: %T %v", err, err)
+				return fmt.Errorf("dependency could not be deleted: %v", err)
 			}
 
 			repo := vendor.GitRepo{

--- a/cmd/gb-vendor/update.go
+++ b/cmd/gb-vendor/update.go
@@ -110,7 +110,6 @@ var UpdateCmd = &cmd.Command{
 			if err := wc.Destroy(); err != nil {
 				return err
 			}
-			fmt.Println(dependencies)
 		}
 
 		return vendor.WriteManifest(manifestFile(ctx), m)

--- a/cmd/gb-vendor/vendor/manifest.go
+++ b/cmd/gb-vendor/vendor/manifest.go
@@ -30,8 +30,8 @@ func (m *Manifest) AddDependency(dep Dependency) error {
 	return nil
 }
 
-// RemoveDependency removes a Dependency from the current Manifest
-// If the dependency does not exist then it returns an error
+// RemoveDependency removes a Dependency from the current Manifest.
+// If the dependency does not exist then it returns an error.
 func (m *Manifest) RemoveDependency(dep Dependency) error {
 	for i, d := range m.Dependencies {
 		if reflect.DeepEqual(d, dep) {

--- a/cmd/gb-vendor/vendor/repo.go
+++ b/cmd/gb-vendor/vendor/repo.go
@@ -22,8 +22,14 @@ type Repository interface {
 // WorkingCopy represents a local copy of a remote dvcs repository.
 type WorkingCopy interface {
 
-	// Dir is the root of this working copy
+	// Dir is the root of this working copy.
 	Dir() string
+
+	// Checks out specific branch of this working copy.
+	CheckoutBranch(string) error
+
+	// Checks out specific revision of this working copy.
+	CheckoutRevision(string) error
 
 	// Revision returns the revision of this working copy.
 	Revision() (string, error)
@@ -31,7 +37,7 @@ type WorkingCopy interface {
 	// Branch returns the branch to which this working copy belongs.
 	Branch() (string, error)
 
-	// Destroy removes the working copy
+	// Destroy removes the working copy.
 	Destroy() error
 }
 
@@ -64,6 +70,16 @@ type GitClone struct {
 }
 
 func (g *GitClone) Dir() string { return g.Path }
+
+func (g *GitClone) CheckoutBranch(branch string) error {
+	_, err := run("git", "-C", g.Path, "checkout", "-b", branch, "origin/"+branch)
+	return err
+}
+
+func (g *GitClone) CheckoutRevision(revision string) error {
+	_, err := run("git", "-C", g.Path, "checkout", revision)
+	return err
+}
 
 func (g *GitClone) Revision() (string, error) {
 	rev, err := run("git", "-C", g.Path, "rev-parse", "HEAD")


### PR DESCRIPTION
Updates #126 
Implements (only `gb vendor fetch` for now) #136
Fixes #137 

Added support for `--all`, `--branch`, `--revision` flag in `gb vendor fetch`.
Added support for `--all` flag in `gb vendor update`:
* I think `gb vendor update` should not have `--branch` and `--revision` flag, since it should get those from Manifest file and pull last revision of the branch specified in the Manifest file (explained in detail in  [#136](https://github.com/constabulary/gb/issues/136#issuecomment-105551838)).

Possible issue:
~~* after calling `gb vendor delete <package>`, package's parent directory stays empty~~ Fixed

**NOTES:**
* Checking out revision (commit sha) places git repository into Detached HEAD -> branch name becomes *HEAD* (also in manifest file)