### PR TITLE
gb: isStale returns true if compiler is newer than source

### DIFF
--- a/gb.go
+++ b/gb.go
@@ -21,6 +21,12 @@ type Toolchain interface {
 	Pack(pkg *Package, afiles ...string) error
 	Ld(*Package, []string, []string, string, string) error
 	Cc(pkg *Package, ofile string, cfile string) error
+
+	// compiler returns the location of the compiler for .go source code
+	compiler() string
+
+	// linker returns the location of the linker for this toolchain
+	linker() string
 }
 
 func mktmpdir() string {

--- a/gc.go
+++ b/gc.go
@@ -19,3 +19,6 @@ func (t *gcToolchain) Pack(pkg *Package, afiles ...string) error {
 	dir := filepath.Dir(afiles[0])
 	return pkg.run(dir, nil, t.pack, args...)
 }
+
+func (t *gcToolchain) compiler() string { return t.gc }
+func (t *gcToolchain) linker() string   { return t.ld }


### PR DESCRIPTION
This is a fix from the go tool which causes packages to be considered stale
if they are newer than the compiler that built them. This happens often if
using the trunk compiler