### PR TITLE
cmd/gb-vendor: add gb vendor list subcommand

### DIFF
--- a/cmd/gb-vendor/list.go
+++ b/cmd/gb-vendor/list.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"html/template"
+	"os"
+
+	"github.com/constabulary/gb"
+	"github.com/constabulary/gb/cmd"
+	"github.com/constabulary/gb/cmd/gb-vendor/vendor"
+)
+
+func init() {
+	registerCommand("list", List)
+}
+
+var format string
+
+var List = &cmd.Command{
+	ShortDesc: "lists the packages named by the import paths, one per line.",
+	Run: func(ctx *gb.Context, args []string) error {
+		m, err := vendor.ReadManifest(manifestFile(ctx))
+		if err != nil {
+			return fmt.Errorf("could not load manifest: %v", err)
+		}
+		tmpl, err := template.New("list").Parse(format)
+		if err != nil {
+			return fmt.Errorf("unable to parse template %q: %v", format, err)
+		}
+
+		for _, dep := range m.Dependencies {
+			if err := tmpl.Execute(os.Stdout, dep); err != nil {
+				return fmt.Errorf("unable to execute template: %v", err)
+			}
+			fmt.Fprintln(os.Stdout)
+		}
+		return nil
+	},
+	AddFlags: func(fs *flag.FlagSet) {
+		fs.StringVar(&format, "f", "{{.Importpath}}\t{{.Repository}}{{.Path}}\t{{.Branch}}\t{{.Revision}}", "format template")
+	},
+}


### PR DESCRIPTION
Adds `gb vendor list`
```
% gb vendor list
github.com/kr/fs        https://github.com/kr/fs/       master  2788f0dbd16903de03cb8186e5c7d97b69ad387b
github.com/pkg/sftp/examples    https://github.com/pkg/sftp/examples    master  db7130eb6883678c3db453ba359e19306657528f
```