### PR TITLE
Add Command.ParseArgs

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -24,6 +24,11 @@ type Command struct {
 
 	// Allow plugins to modify arguments
 	FlagParse func(fs *flag.FlagSet, args []string) error
+
+	// ParseArgs provides an alterntive method to parse arguments.
+	// By default, arguments will be parsed as import paths with
+	// ImportPaths
+	ParseArgs func(ctx *gb.Context, cwd string, args []string) []string
 }
 
 // RunCommand detects the project root, parses flags and runs the Command.

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -50,7 +50,6 @@ func main() {
 	}
 
 	name := args[1]
-	parseargs := name != "plugin"
 	command, ok := commands[name]
 	if !ok {
 		if _, err := lookupPlugin(name); err != nil {
@@ -60,7 +59,6 @@ func main() {
 		}
 		command = commands["plugin"]
 		args = append([]string{"plugin"}, args...)
-		parseargs = false // don't parse args as import paths
 	}
 
 	// add extra flags if necessary
@@ -100,9 +98,12 @@ func main() {
 		gb.Fatalf("unable to construct context: %v", err)
 	}
 
-	if parseargs {
+	if command.ParseArgs != nil {
+		args = command.ParseArgs(ctx, cwd, args)
+	} else {
 		args = cmd.ImportPaths(ctx, cwd, args)
 	}
+
 	gb.Debugf("args: %v", args)
 	if err := command.Run(ctx, args); err != nil {
 		gb.Fatalf("command %q failed: %v", name, err)

--- a/cmd/gb/plugin.go
+++ b/cmd/gb/plugin.go
@@ -42,6 +42,8 @@ var PluginCmd = &cmd.Command{
 
 		return cmd.Run()
 	},
+	// plugin should not interpret arguments
+	ParseArgs: func(_ *gb.Context, _ string, args []string) []string { return args },
 }
 
 func lookupPlugin(arg string) (string, error) {


### PR DESCRIPTION
Currently the command handling logic will interpret arguments to
all comamnds as import paths unless the name of the command is `plugin`,
then it won't.

Make this more flexible by removing the hard coded name and replacing it
with a function on the Command structure with a reasonable default.