### PR TITLE
cmd/gb: add gb doc

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -27,6 +27,11 @@ type Command struct {
 
 	// Allow plugins to modify arguments
 	FlagParse func(fs *flag.FlagSet, args []string) error
+
+	// ParseArgs provides an alterntive method to parse arguments.
+	// By default, arguments will be parsed as import paths with
+	// ImportPaths
+	ParseArgs func(ctx *gb.Context, cwd string, args []string) []string
 }
 
 // RunCommand detects the project root, parses flags and runs the Command.

--- a/cmd/gb-vendor/list.go
+++ b/cmd/gb-vendor/list.go
@@ -12,12 +12,13 @@ import (
 )
 
 func init() {
-	registerCommand("list", List)
+	registerCommand(List)
 }
 
 var format string
 
 var List = &cmd.Command{
+	Name:      "list",
 	ShortDesc: "lists the packages named by the import paths, one per line.",
 	Run: func(ctx *gb.Context, args []string) error {
 		m, err := vendor.ReadManifest(manifestFile(ctx))

--- a/cmd/gb/doc.go
+++ b/cmd/gb/doc.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/constabulary/gb"
+	"github.com/constabulary/gb/cmd"
+)
+
+func init() {
+	registerCommand("doc", &cmd.Command{
+		ShortDesc: "show documentation for a package or symbol",
+		Run: func(ctx *gb.Context, args []string) error {
+			env := cmd.MergeEnv(os.Environ(), map[string]string{
+				"GOPATH": fmt.Sprintf("%s:%s", ctx.Projectdir(), filepath.Join(ctx.Projectdir(), "vendor")),
+			})
+			if len(args) == 0 {
+				args = append(args, ".")
+			}
+			args = append([]string{filepath.Join(ctx.GOROOT, "bin", "godoc")}, args...)
+
+			cmd := exec.Cmd{
+				Path: args[0],
+				Args: args,
+				Env:  env,
+
+				Stdin:  os.Stdin,
+				Stdout: os.Stdout,
+				Stderr: os.Stderr,
+			}
+			return cmd.Run()
+		},
+		ParseArgs: func(_ *gb.Context, _ string, args []string) []string { return args },
+	})
+}

--- a/cmd/gb/doc.go
+++ b/cmd/gb/doc.go
@@ -11,7 +11,8 @@ import (
 )
 
 func init() {
-	registerCommand("doc", &cmd.Command{
+	registerCommand(&cmd.Command{
+		Name: "doc",
 		ShortDesc: "show documentation for a package or symbol",
 		Run: func(ctx *gb.Context, args []string) error {
 			env := cmd.MergeEnv(os.Environ(), map[string]string{

--- a/cmd/gb/doc.go
+++ b/cmd/gb/doc.go
@@ -11,9 +11,8 @@ import (
 )
 
 func init() {
-<<<<<<< HEAD
 	registerCommand(&cmd.Command{
-		Name: "doc",
+		Name:      "doc",
 		ShortDesc: "show documentation for a package or symbol",
 		Run: func(ctx *gb.Context, args []string) error {
 			env := cmd.MergeEnv(os.Environ(), map[string]string{

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -58,7 +58,6 @@ func main() {
 	}
 
 	name := args[1]
-	parseargs := name != "plugin"
 	command, ok := commands[name]
 	if !ok {
 		if _, err := lookupPlugin(name); err != nil {
@@ -68,7 +67,6 @@ func main() {
 		}
 		command = commands["plugin"]
 		args = append([]string{"plugin"}, args...)
-		parseargs = false // don't parse args as import paths
 	}
 
 	// add extra flags if necessary
@@ -108,9 +106,12 @@ func main() {
 		gb.Fatalf("unable to construct context: %v", err)
 	}
 
-	if parseargs {
+	if command.ParseArgs != nil {
+		args = command.ParseArgs(ctx, cwd, args)
+	} else {
 		args = cmd.ImportPaths(ctx, cwd, args)
 	}
+
 	gb.Debugf("args: %v", args)
 	if err := command.Run(ctx, args); err != nil {
 		gb.Fatalf("command %q failed: %v", name, err)

--- a/cmd/gb/plugin.go
+++ b/cmd/gb/plugin.go
@@ -43,6 +43,8 @@ var PluginCmd = &cmd.Command{
 
 		return cmd.Run()
 	},
+	// plugin should not interpret arguments
+	ParseArgs: func(_ *gb.Context, _ string, args []string) []string { return args },
 }
 
 func lookupPlugin(arg string) (string, error) {


### PR DESCRIPTION
Fixes #74 

gb doc is a simple wrapper around go doc / godoc. Invocation is the same

    gb doc $PACKAGE
    gb doc $PACKAGE $SYMBOL

Without arguments gb doc behaves as if you had passed `gb doc .` which
expands to the current working directory.