### PR TITLE
Fix a panic and a manifest update bug for gb vendor

### DIFF
--- a/cmd/gb-vendor/main.go
+++ b/cmd/gb-vendor/main.go
@@ -79,7 +79,7 @@ func main() {
 			}
 
 			if err := command.Run(ctx, args); err != nil {
-				gb.Fatalf("command %q failed: %v", args[0], err)
+				gb.Fatalf("command %q failed: %v", command.Name, err)
 			}
 			return
 		}

--- a/cmd/gb-vendor/update.go
+++ b/cmd/gb-vendor/update.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"path"
 	"path/filepath"
 
 	"github.com/constabulary/gb"
@@ -75,9 +74,9 @@ Flags:
 				return fmt.Errorf("dependency could not be deleted: %v", err)
 			}
 
-			repo, extra, err := vendor.RepositoryFromPath(path.Join(url, p))
+			repo, extra, err := vendor.RepositoryFromPath(p)
 			if err != nil {
-				return fmt.Errorf("could not determine repository for import %q", path.Join(url, p))
+				return fmt.Errorf("could not determine repository for import %q", p)
 			}
 
 			wc, err := repo.Clone()


### PR DESCRIPTION
This PR fixes 2 issues:

Issue 1:
```sh
$ gb vendor update
panic: runtime error: index out of range

goroutine 1 [running]:
main.main()
	/.../constabulary/gb/cmd/gb-vendor/main.go:82 +0xb88
```

Issue 2: It shouldn't join the repository URL with the import path:
```sh
$ cat vendor/manifest
{
	"version": 0,
	"dependencies": [
		{
			"importpath": "github.com/constabulary/gb",
			"repository": "https://github.com/constabulary/gb",
			"revision": "119ad549aac0dcc74cc9d1dd48cd672be8d4b4aa",
			"branch": "master",
			"path": ""
		}
	]
}

$ gb vendor update -all
FATAL command "update" failed: could not determine repository for import "https:/github.com/constabulary/gb/github.com/constabulary/gb"
FATAL command "vendor" failed: exit status 1
```