### PR TITLE
Add support for gopkg.in imports

### DIFF
--- a/cmd/gb-vendor/vendor/repo.go
+++ b/cmd/gb-vendor/vendor/repo.go
@@ -50,6 +50,7 @@ type WorkingCopy interface {
 var (
 	ghregex = regexp.MustCompile(`^github.com/([A-Za-z0-9-._]+)/([A-Za-z0-9-._]+)(/.+)?`)
 	bbregex = regexp.MustCompile(`^bitbucket.org/([A-Za-z0-9-._]+)/([A-Za-z0-9-._]+)(/.+)?`)
+	gpregex = regexp.MustCompile(`^gopkg.in/(([A-Za-z0-9-._]+/)?[A-Za-z0-9-._]+\.v[0-9]+)`)
 )
 
 // RepositoryFromPath attempts to deduce a Repository from an import path.
@@ -73,6 +74,10 @@ func RepositoryFromPath(path string) (Repository, string, error) {
 				&GitRepo{url: fmt.Sprintf("https://bitbucket.org/%s/%s", v[1], v[2])},
 			},
 		}, v[3], nil
+	case gpregex.MatchString(path):
+		v := gpregex.FindStringSubmatch(path)
+		v = append(v, "")
+		return &GitRepo{url: fmt.Sprintf("https://gopkg.in/%s", v[1])}, "", nil
 	default:
 		return nil, path, fmt.Errorf("unknown repository type")
 	}

--- a/cmd/gb-vendor/vendor/repo_test.go
+++ b/cmd/gb-vendor/vendor/repo_test.go
@@ -44,6 +44,16 @@ func TestRepositoryFromPath(t *testing.T) {
 			},
 		},
 		extra: "/sub/directory",
+	}, {
+		path: "gopkg.in/pg.v3",
+		want: &GitRepo{
+			url: "https://gopkg.in/pg.v3",
+		},
+	}, {
+		path: "gopkg.in/user/pkg.v1",
+		want: &GitRepo{
+			url: "https://gopkg.in/user/pkg.v1",
+		},
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
I don't necessarily like that this needs to be supported, but since some existing libraries use the gopkg.in import path, I have to be able to import them as such in my vendor dir. Since gopkg.in acts as a git mirror, we can treat this just like a git repo.

I figured I'd make a PR in case this should be included, but I won't be offended if the PR just gets closed :) (I'll keep the change locally and hope that one day these libraries stop using gopkg.in).

In any case, this should work just like the other formats:

    gb vendor fetch gopkg.in/pg.v3

to fetch gopkg.in/pg.v3.