### PR TITLE
cmd/gb-vendor: add support for vanity imports

### DIFF
--- a/cmd/gb-vendor/main.go
+++ b/cmd/gb-vendor/main.go
@@ -96,7 +96,7 @@ func manifestFile(ctx *gb.Context) string {
 // copypath copies the contents of src to dst, excluding any file or
 // directory that starts with a period.
 func copypath(dst string, src string) error {
-	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -115,6 +115,11 @@ func copypath(dst string, src string) error {
 		dst := filepath.Join(dst, path[len(src):])
 		return copyfile(dst, path)
 	})
+	if err != nil {
+		// if there was an error during copying, remove the partial copy.
+		os.RemoveAll(dst)
+	}
+	return err
 }
 
 func copyfile(dst, src string) error {

--- a/cmd/gb-vendor/vendor/discovery.go
+++ b/cmd/gb-vendor/vendor/discovery.go
@@ -1,0 +1,80 @@
+// Copyright 2012 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vendor
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// charsetReader returns a reader for the given charset. Currently
+// it only supports UTF-8 and ASCII. Otherwise, it returns a meaningful
+// error which is printed by go get, so the user can find why the package
+// wasn't downloaded if the encoding is not supported. Note that, in
+// order to reduce potential errors, ASCII is treated as UTF-8 (i.e. characters
+// greater than 0x7f are not rejected).
+func charsetReader(charset string, input io.Reader) (io.Reader, error) {
+	switch strings.ToLower(charset) {
+	case "ascii":
+		return input, nil
+	default:
+		return nil, fmt.Errorf("can't decode XML document using charset %q", charset)
+	}
+}
+
+type metaImport struct {
+	Prefix, VCS, RepoRoot string
+}
+
+// parseMetaGoImports returns meta imports from the HTML in r.
+// Parsing ends at the end of the <head> section or the beginning of the <body>.
+func parseMetaGoImports(r io.Reader) (imports []metaImport, err error) {
+	d := xml.NewDecoder(r)
+	d.CharsetReader = charsetReader
+	d.Strict = false
+	var t xml.Token
+	for {
+		t, err = d.Token()
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+			return
+		}
+		if e, ok := t.(xml.StartElement); ok && strings.EqualFold(e.Name.Local, "body") {
+			return
+		}
+		if e, ok := t.(xml.EndElement); ok && strings.EqualFold(e.Name.Local, "head") {
+			return
+		}
+		e, ok := t.(xml.StartElement)
+		if !ok || !strings.EqualFold(e.Name.Local, "meta") {
+			continue
+		}
+		if attrValue(e.Attr, "name") != "go-import" {
+			continue
+		}
+		if f := strings.Fields(attrValue(e.Attr, "content")); len(f) == 3 {
+			imports = append(imports, metaImport{
+				Prefix:   f[0],
+				VCS:      f[1],
+				RepoRoot: f[2],
+			})
+		}
+	}
+}
+
+// attrValue returns the attribute value for the case-insensitive key
+// `name', or the empty string if nothing is found.
+func attrValue(attrs []xml.Attr, name string) string {
+	for _, a := range attrs {
+		if strings.EqualFold(a.Name.Local, name) {
+			return a.Value
+		}
+	}
+	return ""
+}

--- a/cmd/gb-vendor/vendor/imports_test.go
+++ b/cmd/gb-vendor/vendor/imports_test.go
@@ -1,6 +1,8 @@
 package vendor
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -18,6 +20,90 @@ func TestParseImports(t *testing.T) {
 	want := set("github.com/quux/flobble", "github.com/lypo/moopo", "github.com/hoo/wuu")
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("ParseImports(%q): want: %v, got %v", root, want, got)
+	}
+}
+
+func TestFetchMetadata(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{{
+		path: "golang.org/x/tools/cmd/godoc",
+		want: `<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<meta name="go-import" content="golang.org/x/tools git https://go.googlesource.com/tools">
+<meta name="go-source" content="golang.org/x/tools https://github.com/golang/tools/ https://github.com/golang/tools/tree/master{/dir} https://github.com/golang/tools/blob/master{/dir}/{file}#L{line}">
+<meta http-equiv="refresh" content="0; url=https://godoc.org/golang.org/x/tools/cmd/godoc">
+</head>
+<body>
+Nothing to see here; <a href="https://godoc.org/golang.org/x/tools/cmd/godoc">move along</a>.
+</body>
+</html>
+`,
+	}, {
+		path: "gopkg.in/check.v1",
+		want: `
+<html>
+<head>
+<meta name="go-import" content="gopkg.in/check.v1 git https://gopkg.in/check.v1">
+<meta name="go-source" content="gopkg.in/check.v1 _ https://github.com/go-check/check/tree/v1{/dir} https://github.com/go-check/check/blob/v1{/dir}/{file}#L{line}">
+</head>
+<body>
+go get gopkg.in/check.v1
+</body>
+</html>
+`,
+	}}
+
+	for _, tt := range tests {
+		r, err := FetchMetadata(tt.path)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, r); err != nil {
+			t.Error(err)
+			r.Close()
+			continue
+		}
+		r.Close()
+		got := buf.String()
+		if got != tt.want {
+			t.Errorf("FetchMetadata(%q): want %q, got %q", tt.path, tt.want, got)
+		}
+	}
+}
+
+func TestParseMetadata(t *testing.T) {
+	tests := []struct {
+		path       string
+		importpath string
+		vcs        string
+		reporoot   string
+	}{{
+		path:       "golang.org/x/tools/cmd/godoc",
+		importpath: "golang.org/x/tools",
+		vcs:        "git",
+		reporoot:   "https://go.googlesource.com/tools",
+	}, {
+		path:       "gopkg.in/check.v1",
+		importpath: "gopkg.in/check.v1",
+		vcs:        "git",
+		reporoot:   "https://gopkg.in/check.v1",
+	}}
+
+	for _, tt := range tests {
+		importpath, vcs, reporoot, err := ParseMetadata(tt.path)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		if importpath != tt.importpath || vcs != tt.vcs || reporoot != tt.reporoot {
+			t.Errorf("ParseMetadata(%q): want %s %s %s, got %s %s %s ", tt.path, tt.importpath, tt.vcs, tt.reporoot, importpath, vcs, reporoot)
+		}
 	}
 }
 

--- a/cmd/gb-vendor/vendor/repo_test.go
+++ b/cmd/gb-vendor/vendor/repo_test.go
@@ -13,43 +13,50 @@ func TestRepositoryFromPath(t *testing.T) {
 		err   error
 	}{{
 		path: "github.com/pkg/sftp",
-		want: &GitRepo{
+		want: &gitrepo{
 			url: "https://github.com/pkg/sftp",
 		},
 	}, {
 		path: "github.com/pkg/sftp/examples/gsftp",
-		want: &GitRepo{
+		want: &gitrepo{
 			url: "https://github.com/pkg/sftp",
 		},
 		extra: "/examples/gsftp",
 	}, {
 		path: "github.com/coreos/go-etcd",
-		want: &GitRepo{
+		want: &gitrepo{
 			url: "https://github.com/coreos/go-etcd",
 		},
 	}, {
-		path: "bitbucket.org/StephaneBunel/xxhash-go",
-		want: &MultiRepo{
-			remotes: []Repository{
-				&HgRepo{url: "https://bitbucket.org/StephaneBunel/xxhash-go"},
-				&GitRepo{url: "https://bitbucket.org/StephaneBunel/xxhash-go"},
-			},
+		path: "bitbucket.org/davecheney/gitrepo/cmd/main",
+		want: &gitrepo{
+			url: "https://bitbucket.org/davecheney/gitrepo",
 		},
+		extra: "/cmd/main",
 	}, {
-		path: "bitbucket.org/user/project/sub/directory",
-		want: &MultiRepo{
-			remotes: []Repository{
-				&HgRepo{url: "https://bitbucket.org/user/project"},
-				&GitRepo{url: "https://bitbucket.org/user/project"},
-			},
+		path: "bitbucket.org/davecheney/hgrepo/cmd/main",
+		want: &hgrepo{
+			url: "https://bitbucket.org/davecheney/hgrepo",
 		},
-		extra: "/sub/directory",
+		extra: "/cmd/main",
+	}, {
+		path: "gopkg.in/check.v1",
+		want: &gitrepo{
+			url: "https://gopkg.in/check.v1",
+		},
+		extra: "",
+	}, {
+		path: "golang.org/x/tools/go/vcs",
+		want: &gitrepo{
+			url: "https://go.googlesource.com/tools",
+		},
+		extra: "/go/vcs",
 	}}
 
 	for _, tt := range tests {
 		got, extra, err := RepositoryFromPath(tt.path)
 		if !reflect.DeepEqual(got, tt.want) || extra != tt.extra || err != tt.err {
-			t.Errorf("RepositoryFromPath(%q): want %v, %v, %v, got %v, %v, %v", tt.path, tt.want, tt.extra, tt.err, got, extra, err)
+			t.Errorf("RepositoryFromPath(%q): want %#v, %v, %v, got %#v, %v, %v", tt.path, tt.want, tt.extra, tt.err, got, extra, err)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #177 
Fixes #178 

This PR adds initial support to `gb vendor` for handling so called 'vanity' import paths.

Included are some regrettable tests which require network access, this is probably unavoidable without mocking out the http layer, so for the moment we'll live with it.

```
 % gb vendor fetch golang.org/x/crypto/pbkdf2
Cloning into '/tmp/gb-vendor-402709523'...
remote: Total 1922 (delta 1207), reused 1922 (delta 1207)
Receiving objects: 100% (1922/1922), 1.42 MiB | 403.00 KiB/s, done.
Resolving deltas: 100% (1207/1207), done.
Checking connectivity... done.
copyfile(dst: /home/dfc/devel/juju/vendor/src/golang.org/x/crypto/pbkdf2/pbkdf2.go, src: /tmp/gb-vendor-402709523/pbkdf2/pbkdf2.go)
copyfile(dst: /home/dfc/devel/juju/vendor/src/golang.org/x/crypto/pbkdf2/pbkdf2_test.go, src: /tmp/gb-vendor-402709523/pbkdf2/pbkdf2_test.go)
```