### PR TITLE
cmd/gb-vendor: move copypath to vendor.Copypath, skip symlinks

### DIFF
--- a/cmd/gb-vendor/fetch.go
+++ b/cmd/gb-vendor/fetch.go
@@ -99,7 +99,7 @@ Flags:
 		dst := filepath.Join(ctx.Projectdir(), "vendor", "src", dep.Importpath)
 		src := filepath.Join(wc.Dir(), dep.Path)
 
-		if err := copypath(dst, src); err != nil {
+		if err := vendor.Copypath(dst, src); err != nil {
 			return err
 		}
 

--- a/cmd/gb-vendor/main.go
+++ b/cmd/gb-vendor/main.go
@@ -2,11 +2,8 @@ package main
 
 import (
 	"flag"
-	"fmt"
-	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
@@ -91,56 +88,4 @@ const manifestfile = "manifest"
 
 func manifestFile(ctx *gb.Context) string {
 	return filepath.Join(ctx.Projectdir(), "vendor", manifestfile)
-}
-
-// copypath copies the contents of src to dst, excluding any file or
-// directory that starts with a period.
-func copypath(dst string, src string) error {
-	err := filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if strings.HasPrefix(filepath.Base(path), ".") {
-			if info.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-
-		if info.IsDir() {
-			return nil
-		}
-
-		dst := filepath.Join(dst, path[len(src):])
-		return copyfile(dst, path)
-	})
-	if err != nil {
-		// if there was an error during copying, remove the partial copy.
-		os.RemoveAll(dst)
-	}
-	return err
-}
-
-func copyfile(dst, src string) error {
-	err := mkdir(filepath.Dir(dst))
-	if err != nil {
-		return fmt.Errorf("copyfile: mkdirall: %v", err)
-	}
-	r, err := os.Open(src)
-	if err != nil {
-		return fmt.Errorf("copyfile: open(%q): %v", src, err)
-	}
-	defer r.Close()
-	w, err := os.Create(dst)
-	if err != nil {
-		return fmt.Errorf("copyfile: create(%q): %v", dst, err)
-	}
-	fmt.Printf("copyfile(dst: %v, src: %v)\n", dst, src)
-	_, err = io.Copy(w, r)
-	return err
-}
-
-func mkdir(path string) error {
-	return os.MkdirAll(path, 0755)
 }

--- a/cmd/gb-vendor/update.go
+++ b/cmd/gb-vendor/update.go
@@ -109,7 +109,7 @@ Flags:
 			dst := filepath.Join(ctx.Projectdir(), "vendor", "src", dep.Importpath)
 			src := filepath.Join(wc.Dir(), dep.Path)
 
-			if err := copypath(dst, src); err != nil {
+			if err := vendor.Copypath(dst, src); err != nil {
 				return err
 			}
 

--- a/cmd/gb-vendor/vendor/_testdata/copyfile/a/rick
+++ b/cmd/gb-vendor/vendor/_testdata/copyfile/a/rick
@@ -1,0 +1,1 @@
+/never/going/to/give/you/up

--- a/cmd/gb-vendor/vendor/copy.go
+++ b/cmd/gb-vendor/vendor/copy.go
@@ -1,0 +1,57 @@
+package vendor
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Copypath copies the contents of src to dst, excluding any file or
+// directory that starts with a period.
+func Copypath(dst string, src string) error {
+	err := filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if strings.HasPrefix(filepath.Base(path), ".") {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		dst := filepath.Join(dst, path[len(src):])
+		return copyfile(dst, path)
+	})
+	if err != nil {
+		// if there was an error during copying, remove the partial copy.
+		os.RemoveAll(dst)
+	}
+	return err
+}
+
+func copyfile(dst, src string) error {
+	err := mkdir(filepath.Dir(dst))
+	if err != nil {
+		return fmt.Errorf("copyfile: mkdirall: %v", err)
+	}
+	r, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("copyfile: open(%q): %v", src, err)
+	}
+	defer r.Close()
+	w, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("copyfile: create(%q): %v", dst, err)
+	}
+	fmt.Printf("copyfile(dst: %v, src: %v)\n", dst, src)
+	_, err = io.Copy(w, r)
+	return err
+}

--- a/cmd/gb-vendor/vendor/copy.go
+++ b/cmd/gb-vendor/vendor/copy.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 )
 
+const debugCopypath = true
+const debugCopyfile = false
+
 // Copypath copies the contents of src to dst, excluding any file or
 // directory that starts with a period.
 func Copypath(dst string, src string) error {
@@ -24,6 +27,13 @@ func Copypath(dst string, src string) error {
 		}
 
 		if info.IsDir() {
+			return nil
+		}
+
+		if info.Mode()&os.ModeSymlink != 0 {
+			if debugCopypath {
+				fmt.Printf("skiping symlink: %v\n", path)
+			}
 			return nil
 		}
 
@@ -51,7 +61,9 @@ func copyfile(dst, src string) error {
 	if err != nil {
 		return fmt.Errorf("copyfile: create(%q): %v", dst, err)
 	}
-	fmt.Printf("copyfile(dst: %v, src: %v)\n", dst, src)
+	if debugCopyfile {
+		fmt.Printf("copyfile(dst: %v, src: %v)\n", dst, src)
+	}
 	_, err = io.Copy(w, r)
 	return err
 }

--- a/cmd/gb-vendor/vendor/copy_test.go
+++ b/cmd/gb-vendor/vendor/copy_test.go
@@ -1,0 +1,20 @@
+package vendor
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestCopypathSkipsSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no symlinks on windows y'all")
+	}
+	dst := mktemp(t)
+	defer os.RemoveAll(dst)
+	src := filepath.Join("_testdata", "copyfile", "a")
+	if err := Copypath(dst, src); err != nil {
+		t.Fatal("copypath(%s, %s): %v", dst, src, err)
+	}
+}

--- a/cmd/gb-vendor/vendor/copy_test.go
+++ b/cmd/gb-vendor/vendor/copy_test.go
@@ -15,6 +15,6 @@ func TestCopypathSkipsSymlinks(t *testing.T) {
 	defer os.RemoveAll(dst)
 	src := filepath.Join("_testdata", "copyfile", "a")
 	if err := Copypath(dst, src); err != nil {
-		t.Fatal("copypath(%s, %s): %v", dst, src, err)
+		t.Fatalf("copypath(%s, %s): %v", dst, src, err)
 	}
 }


### PR DESCRIPTION
Fixes #184 

Ignore symlinks in the src directory.

Also mutes debugging output from `copyfile`
