### PR TITLE
Clean up temporary files on build error

### DIFF
--- a/cmd/gb/build.go
+++ b/cmd/gb/build.go
@@ -80,9 +80,11 @@ For more about specifying packages, see 'gb help packages'. For more about where
 
 		pkgs, err := cmd.ResolvePackages(ctx, args...)
 		if err != nil {
+			ctx.Destroy()
 			return err
 		}
 		if err := gb.Build(pkgs...); err != nil {
+			ctx.Destroy()
 			return err
 		}
 		return ctx.Destroy()


### PR DESCRIPTION
When doing a failed build the temporary directories don't get removed.