### PR TITLE
fix,test(vendor): vendor fetch fail with pkg name length equal 1

### DIFF
--- a/cmd/gb-vendor/vendor/repo.go
+++ b/cmd/gb-vendor/vendor/repo.go
@@ -52,7 +52,7 @@ var (
 // DeduceRemoteRepo takes a potential import path and returns a RemoteRepo
 // representing the remote location of the source of an import path.
 func DeduceRemoteRepo(path string) (RemoteRepo, string, error) {
-	validimport := regexp.MustCompile(`^([A-Za-z0-9-]+)(.[A-Za-z0-9-]+)+(/.[A-Za-z0-9-_.]+)+$`)
+	validimport := regexp.MustCompile(`^([A-Za-z0-9-]+)(.[A-Za-z0-9-]+)+(/.[A-Za-z0-9-_.]*)+$`)
 	if !validimport.MatchString(path) {
 		return nil, "", fmt.Errorf("%q is not a valid import path", path)
 	}

--- a/cmd/gb-vendor/vendor/repo_test.go
+++ b/cmd/gb-vendor/vendor/repo_test.go
@@ -19,6 +19,11 @@ func TestDeduceRemoteRepo(t *testing.T) {
 		path: "corporate",
 		err:  fmt.Errorf(`"corporate" is not a valid import path`),
 	}, {
+		path: "github.com/cznic/b",
+		want: &gitrepo{
+			url: "https://github.com/cznic/b",
+		},
+	}, {
 		path: "github.com/pkg/sftp",
 		want: &gitrepo{
 			url: "https://github.com/pkg/sftp",


### PR DESCRIPTION
Fixes #203 

fix vendor fetch validimport regexp.
create test for package name length equal 1.