### PR TITLE
gb-vendor: add support for fetching a tag

### DIFF
--- a/cmd/gb-vendor/alldocs.go
+++ b/cmd/gb-vendor/alldocs.go
@@ -28,14 +28,17 @@ Fetch a remote dependency
 
 Usage:
 
-        gb vendor fetch [-branch branch] [-revision rev] importpath
+        gb vendor fetch [-branch branch] [-revision rev|-tag tag] importpath
 
 fetch vendors the upstream import path.
 
 Flags:
 	-branch branch
 		fetch from the name branch. If not supplied the default upstream
-		branch will be used
+		branch will be used.
+	-tag tag
+		fetch the specified tag. If not supplie the default upstream
+		banch will be used.
 	-revision rev
 		fetch the specific revision from the branch (if supplied). If no
 		revision supplied, the latest available will be supplied.

--- a/cmd/gb-vendor/alldocs.go
+++ b/cmd/gb-vendor/alldocs.go
@@ -28,7 +28,7 @@ Fetch a remote dependency
 
 Usage:
 
-        gb vendor fetch [-branch branch] [-revision rev|-tag tag] importpath
+        gb vendor fetch [-branch branch | -revision rev | -tag tag] importpath
 
 fetch vendors the upstream import path.
 
@@ -38,7 +38,7 @@ Flags:
 		branch will be used.
 	-tag tag
 		fetch the specified tag. If not supplie the default upstream
-		banch will be used.
+		branch will be used.
 	-revision rev
 		fetch the specific revision from the branch (if supplied). If no
 		revision supplied, the latest available will be supplied.

--- a/cmd/gb-vendor/fetch.go
+++ b/cmd/gb-vendor/fetch.go
@@ -13,28 +13,33 @@ import (
 var (
 	// gb vendor fetch command flags
 
-	// branch
 	branch string
 
 	// revision (commit)
 	revision string
+
+	tag string
 )
 
 func addFetchFlags(fs *flag.FlagSet) {
 	fs.StringVar(&branch, "branch", "master", "branch of the package")
 	fs.StringVar(&revision, "revision", "", "revision of the package")
+	fs.StringVar(&tag, "tag", "", "tag of the package")
 }
 
 var cmdFetch = &cmd.Command{
 	Name:      "fetch",
-	UsageLine: "fetch [-branch branch] [-revision rev] importpath",
+	UsageLine: "fetch [-branch branch] [-revision rev|-tag tag] importpath",
 	Short:     "fetch a remote dependency",
 	Long: `fetch vendors the upstream import path.
 
 Flags:
 	-branch branch
 		fetch from the name branch. If not supplied the default upstream
-		branch will be used
+		branch will be used.
+	-tag tag
+		fetch the specified tag. If not supplie the default upstream 
+		banch will be used.
 	-revision rev
 		fetch the specific revision from the branch (if supplied). If no
 		revision supplied, the latest available will be supplied.
@@ -60,7 +65,7 @@ Flags:
 			return fmt.Errorf("%s is already vendored", path)
 		}
 
-		wc, err := repo.Checkout(branch, revision)
+		wc, err := repo.Checkout(branch, tag, revision)
 		if err != nil {
 			return err
 		}

--- a/cmd/gb-vendor/fetch.go
+++ b/cmd/gb-vendor/fetch.go
@@ -29,7 +29,7 @@ func addFetchFlags(fs *flag.FlagSet) {
 
 var cmdFetch = &cmd.Command{
 	Name:      "fetch",
-	UsageLine: "fetch [-branch branch] [-revision rev|-tag tag] importpath",
+	UsageLine: "fetch [-branch branch | -revision rev | -tag tag] importpath",
 	Short:     "fetch a remote dependency",
 	Long: `fetch vendors the upstream import path.
 
@@ -39,7 +39,7 @@ Flags:
 		branch will be used.
 	-tag tag
 		fetch the specified tag. If not supplie the default upstream 
-		banch will be used.
+		branch will be used.
 	-revision rev
 		fetch the specific revision from the branch (if supplied). If no
 		revision supplied, the latest available will be supplied.

--- a/cmd/gb-vendor/fetch.go
+++ b/cmd/gb-vendor/fetch.go
@@ -22,7 +22,7 @@ var (
 )
 
 func addFetchFlags(fs *flag.FlagSet) {
-	fs.StringVar(&branch, "branch", "master", "branch of the package")
+	fs.StringVar(&branch, "branch", "", "branch of the package")
 	fs.StringVar(&revision, "revision", "", "revision of the package")
 	fs.StringVar(&tag, "tag", "", "tag of the package")
 }

--- a/cmd/gb-vendor/update.go
+++ b/cmd/gb-vendor/update.go
@@ -74,8 +74,7 @@ Flags:
 				return fmt.Errorf("could not determine repository for import %q", d.Importpath)
 			}
 
-
-			wc, err := repo.Checkout(d.Branch, "")
+			wc, err := repo.Checkout(d.Branch, "", "")
 			if err != nil {
 				return err
 			}

--- a/cmd/gb-vendor/vendor/repo.go
+++ b/cmd/gb-vendor/vendor/repo.go
@@ -153,20 +153,16 @@ func (g *gitrepo) URL() string {
 	return g.url
 }
 
-// Checkout fetchs the remote branch, and optionaly updates to the supplied
-// tag or revision. If both are supplied, an error is returned. If a branch
-// and a tag is supplied, then an error is return. If the branch is blank,
+// Checkout fetchs the remote branch, tag, or revision. If more than one is
+// supplied, an error is returned. If the branch is blank,
 // then the default remote branch will be used. If the branch is "HEAD", an
 // error will be returned.
 func (g *gitrepo) Checkout(branch, tag, revision string) (WorkingCopy, error) {
 	if branch == "HEAD" {
 		return nil, fmt.Errorf("cannot update %q as it has been previously fetched with -tag or -revision. Please use gb vendor delete then fetch again.", g.url)
 	}
-	if !atMostOne(tag, revision) {
-		return nil, fmt.Errorf("only one of tag or revision may be supplied")
-	}
-	if !atMostOne(branch, tag) {
-		return nil, fmt.Errorf("only one of tag or branch may be supplied")
+	if !atMostOne(branch, tag, revision) {
+		return nil, fmt.Errorf("only one of branch, tag or revision may be supplied")
 	}
 	dir, err := mktmp()
 	if err != nil {

--- a/cmd/gb-vendor/vendor/repo.go
+++ b/cmd/gb-vendor/vendor/repo.go
@@ -159,7 +159,7 @@ func (g *gitrepo) URL() string {
 // "HEAD", an error will be returned.
 func (g *gitrepo) Checkout(branch, tag, revision string) (WorkingCopy, error) {
 	if branch == "HEAD" {
-		return nil, fmt.Errorf("cannot checkout HEAD")
+		return nil, fmt.Errorf("cannot update %q as it has been previously fetched with -tag or -revision. Please use gb vendor delete then fetch again.", g.url)
 	}
 	if !atMostOne(tag, revision) {
 		return nil, fmt.Errorf("only one of tag or revision may be supplied")

--- a/cmd/gb-vendor/vendor/repo.go
+++ b/cmd/gb-vendor/vendor/repo.go
@@ -154,9 +154,10 @@ func (g *gitrepo) URL() string {
 }
 
 // Checkout fetchs the remote branch, and optionaly updates to the supplied
-// tag or revision. If both are supplied, an error is returned. If the branch
-// is blank, then the default remote branch will be used. If the branch is
-// "HEAD", an error will be returned.
+// tag or revision. If both are supplied, an error is returned. If a branch
+// and a tag is supplied, then an error is return. If the branch is blank,
+// then the default remote branch will be used. If the branch is "HEAD", an
+// error will be returned.
 func (g *gitrepo) Checkout(branch, tag, revision string) (WorkingCopy, error) {
 	if branch == "HEAD" {
 		return nil, fmt.Errorf("cannot update %q as it has been previously fetched with -tag or -revision. Please use gb vendor delete then fetch again.", g.url)

--- a/cmd/gb-vendor/vendor/repo.go
+++ b/cmd/gb-vendor/vendor/repo.go
@@ -15,11 +15,10 @@ import (
 // RemoteRepo describes a remote dvcs repository.
 type RemoteRepo interface {
 
-	// Checkout checks out the specific branch and revision
-	// If branch is empty, the default branch for the underlying
-	// VCS will be used. If revision is empty, the latest available
-	// revision, taking into account branch, will be fetched.
-	Checkout(branch, revision string) (WorkingCopy, error)
+	// Checkout checks out a specific branch, tag, or revision.
+	// The interpretation of these three values is impementation
+	// specific.
+	Checkout(branch, tag, revision string) (WorkingCopy, error)
 
 	// URL returns the URL the clone was taken from. It should
 	// only be called after Clone.
@@ -154,7 +153,17 @@ func (g *gitrepo) URL() string {
 	return g.url
 }
 
-func (g *gitrepo) Checkout(branch, revision string) (WorkingCopy, error) {
+// Checkout fetchs the remote branch, and optionaly updates to the supplied
+// tag or revision. If both are supplied, an error is returned. If the branch
+// is blank, then the default remote branch will be used. If the branch is
+// "HEAD", an error will be returned.
+func (g *gitrepo) Checkout(branch, tag, revision string) (WorkingCopy, error) {
+	if branch == "HEAD" {
+		return nil, fmt.Errorf("cannot checkout HEAD")
+	}
+	if !atMostOne(tag, revision) {
+		return nil, fmt.Errorf("only one of tag or revision may be supplied")
+	}
 	dir, err := mktmp()
 	if err != nil {
 		return nil, err
@@ -176,8 +185,8 @@ func (g *gitrepo) Checkout(branch, revision string) (WorkingCopy, error) {
 		return nil, err
 	}
 
-	if revision != "" {
-		if err := runOutPath(os.Stderr, dir, "git", "checkout", revision); err != nil {
+	if revision != "" || tag != "" {
+		if err := runOutPath(os.Stderr, dir, "git", "checkout", "-q", oneOf(revision, tag)); err != nil {
 			os.RemoveAll(dir)
 			return nil, err
 		}
@@ -243,7 +252,10 @@ type hgrepo struct {
 
 func (h *hgrepo) URL() string { return h.url }
 
-func (h *hgrepo) Checkout(branch, revision string) (WorkingCopy, error) {
+func (h *hgrepo) Checkout(branch, tag, revision string) (WorkingCopy, error) {
+	if !atMostOne(tag, revision) {
+		return nil, fmt.Errorf("only one of tag or revision may be supplied")
+	}
 	dir, err := mktmp()
 	if err != nil {
 		return nil, err
@@ -316,7 +328,10 @@ func (b *bzrrepo) URL() string {
 	return b.url
 }
 
-func (b *bzrrepo) Checkout(branch, revision string) (WorkingCopy, error) {
+func (b *bzrrepo) Checkout(branch, tag, revision string) (WorkingCopy, error) {
+	if !atMostOne(tag, revision) {
+		return nil, fmt.Errorf("only one of tag or revision may be supplied")
+	}
 	dir, err := mktmp()
 	if err != nil {
 		return nil, err
@@ -391,4 +406,25 @@ func runOutPath(w io.Writer, path string, c string, args ...string) error {
 	cmd.Stdout = w
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+// atMostOne returns true if no more than one string supplied is not empty.
+func atMostOne(args ...string) bool {
+	var c int
+	for _, arg := range args {
+		if arg != "" {
+			c++
+		}
+	}
+	return c < 2
+}
+
+// oneof returns the first non empty string
+func oneOf(args ...string) string {
+	for _, arg := range args {
+		if arg != "" {
+			return arg
+		}
+	}
+	return ""
 }

--- a/cmd/gb-vendor/vendor/repo.go
+++ b/cmd/gb-vendor/vendor/repo.go
@@ -164,6 +164,9 @@ func (g *gitrepo) Checkout(branch, tag, revision string) (WorkingCopy, error) {
 	if !atMostOne(tag, revision) {
 		return nil, fmt.Errorf("only one of tag or revision may be supplied")
 	}
+	if !atMostOne(branch, tag) {
+		return nil, fmt.Errorf("only one of tag or branch may be supplied")
+	}
 	dir, err := mktmp()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #209

This PR adds support for fetching from a tag for all repos, however
tag is ignored by all but git. Hopefully someone with hg or bzr
skills can improve this.

This PR also adds a check to ensure that if a repo, again git, is fetched
from a tag or revision, that update will not let the caller update, as
there is no path from one revision to the next if you are in a detached
state.

The error message is very bad, but at least we don't promise something that
isn't possible.
```
% gb vendor fetch -tag r2015.06.03 gopkg.in/mgo.v2
% gb vendor update gopkg.in/mgo.v2
FATAL command "update" failed: cannot checkout HEAD
FATAL command "vendor" failed: exit status 1
```