### PR TITLE
Support for optional fetching via insecure paths

### DIFF
--- a/cmd/gb-vendor/alldocs.go
+++ b/cmd/gb-vendor/alldocs.go
@@ -42,6 +42,8 @@ Flags:
 	-revision rev
 		fetch the specific revision from the branch (if supplied). If no
 		revision supplied, the latest available will be supplied.
+	-precaire
+		allow the use of insecure protocols.
 
 
 Update a local dependency
@@ -63,6 +65,8 @@ gb vendor fetch [-tag | -revision | -branch] to replace it.
 Flags:
 	-all
 		will update all depdendencies in the manifest, otherwise only the dependency supplied.
+	-precaire
+		allow the use of insecure protocols.
 
 
 Lists dependencies, one per line

--- a/cmd/gb-vendor/fetch.go
+++ b/cmd/gb-vendor/fetch.go
@@ -19,12 +19,15 @@ var (
 	revision string
 
 	tag string
+
+	insecure bool // Allow the use of insecure protocols
 )
 
 func addFetchFlags(fs *flag.FlagSet) {
 	fs.StringVar(&branch, "branch", "", "branch of the package")
 	fs.StringVar(&revision, "revision", "", "revision of the package")
 	fs.StringVar(&tag, "tag", "", "tag of the package")
+	fs.BoolVar(&insecure, "precaire", false, "allow the use of insecure protocols")
 }
 
 var cmdFetch = &cmd.Command{
@@ -43,6 +46,8 @@ Flags:
 	-revision rev
 		fetch the specific revision from the branch (if supplied). If no
 		revision supplied, the latest available will be supplied.
+	-precaire
+		allow the use of insecure protocols.
 
 `,
 	Run: func(ctx *gb.Context, args []string) error {
@@ -56,7 +61,7 @@ Flags:
 			return fmt.Errorf("could not load manifest: %v", err)
 		}
 
-		repo, extra, err := vendor.DeduceRemoteRepo(path)
+		repo, extra, err := vendor.DeduceRemoteRepo(path, insecure)
 		if err != nil {
 			return err
 		}

--- a/cmd/gb-vendor/update.go
+++ b/cmd/gb-vendor/update.go
@@ -20,6 +20,7 @@ var (
 
 func addUpdateFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&updateAll, "all", false, "update all dependencies")
+	fs.BoolVar(&insecure, "precaire", false, "allow the use of insecure protocols")
 }
 
 var cmdUpdate = &cmd.Command{
@@ -39,6 +40,8 @@ gb vendor fetch [-tag | -revision | -branch] to replace it.
 Flags:
 	-all
 		will update all depdendencies in the manifest, otherwise only the dependency supplied.
+	-precaire
+		allow the use of insecure protocols.
 
 `,
 	Run: func(ctx *gb.Context, args []string) error {
@@ -77,7 +80,7 @@ Flags:
 				return fmt.Errorf("dependency could not be deleted: %v", err)
 			}
 
-			repo, extra, err := vendor.DeduceRemoteRepo(d.Importpath)
+			repo, extra, err := vendor.DeduceRemoteRepo(d.Importpath, insecure)
 			if err != nil {
 				return fmt.Errorf("could not determine repository for import %q", d.Importpath)
 			}

--- a/cmd/gb-vendor/vendor/repo.go
+++ b/cmd/gb-vendor/vendor/repo.go
@@ -130,7 +130,7 @@ func DeduceRemoteRepo(path string, insecure bool) (RemoteRepo, string, error) {
 	extra := path[len(importpath):]
 	switch vcs {
 	case "git":
-		repo, err := Gitrepo(u.Host, u.Path[1:], insecure)
+		repo, err := Gitrepo(u.Host, u.Path[1:], insecure, u.Scheme)
 		return repo, extra, err
 	case "hg":
 		repo, err := Hgrepo(reporoot)
@@ -144,8 +144,11 @@ func DeduceRemoteRepo(path string, insecure bool) (RemoteRepo, string, error) {
 }
 
 // Gitrepo returns a RemoteRepo representing a remote git repository.
-func Gitrepo(host, path string, insecure bool) (RemoteRepo, error) {
-	url, err := probeGitUrl(host, path, insecure)
+func Gitrepo(host, path string, insecure bool, schemes ...string) (RemoteRepo, error) {
+	if schemes == nil {
+		schemes = []string{"https", "git", "http"}
+	}
+	url, err := probeGitUrl(schemes, host, path, insecure)
 	if err != nil {
 		return nil, err
 	}
@@ -154,8 +157,8 @@ func Gitrepo(host, path string, insecure bool) (RemoteRepo, error) {
 	}, nil
 }
 
-func probeGitUrl(host, path string, insecure bool) (string, error) {
-	for _, scheme := range []string{"git", "https", "http"} {
+func probeGitUrl(schemes []string, host, path string, insecure bool) (string, error) {
+	for _, scheme := range schemes {
 		switch scheme {
 		case "https":
 			url := scheme + "://" + host + "/" + path

--- a/cmd/gb-vendor/vendor/repo_test.go
+++ b/cmd/gb-vendor/vendor/repo_test.go
@@ -8,10 +8,11 @@ import (
 
 func TestDeduceRemoteRepo(t *testing.T) {
 	tests := []struct {
-		path  string
-		want  RemoteRepo
-		extra string
-		err   error
+		path     string
+		want     RemoteRepo
+		extra    string
+		err      error
+		insecure bool
 	}{{
 		path: "",
 		err:  fmt.Errorf(`"" is not a valid import path`),
@@ -62,6 +63,7 @@ func TestDeduceRemoteRepo(t *testing.T) {
 		want: &gitrepo{
 			url: "git://git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.golang.git",
 		},
+		insecure: true,
 	}, {
 		path: "gopkg.in/check.v1",
 		want: &gitrepo{
@@ -87,7 +89,8 @@ func TestDeduceRemoteRepo(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		got, extra, err := DeduceRemoteRepo(tt.path)
+		t.Logf("DeduceRemoteRepo(%q, %v)", tt.path, tt.insecure)
+		got, extra, err := DeduceRemoteRepo(tt.path, tt.insecure)
 		if !reflect.DeepEqual(err, tt.err) {
 			t.Errorf("DeduceRemoteRepo(%q): want err: %v, got err: %v", tt.path, tt.err, err)
 			continue

--- a/cmd/gb-vendor/vendor/repo_test.go
+++ b/cmd/gb-vendor/vendor/repo_test.go
@@ -61,9 +61,8 @@ func TestDeduceRemoteRepo(t *testing.T) {
 	}, {
 		path: "git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.golang.git",
 		want: &gitrepo{
-			url: "git://git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.golang.git",
+			url: "https://git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.golang.git",
 		},
-		insecure: true,
 	}, {
 		path: "gopkg.in/check.v1",
 		want: &gitrepo{


### PR DESCRIPTION
Fixes #207

Adds support for optional fetching via insecure paths.

`gb fetch` / `update` have a new flag, `--precaire` which enables discovery of insecure repos. It defaults to off.

### TODO
No support for insecure bzr, I'll wait for someone to request it.

### For discussion
Currently `git://` scheme is considered insecure as, while it has no support for pushing, there is no transport security so could be used in a man-in-the-middle attempt.

Who cares enough to debate this ?