### PR TITLE
cmd/gb-vendor/vendor: add support for insecure metadata retrieval

### DIFF
--- a/cmd/gb-vendor/vendor/imports_test.go
+++ b/cmd/gb-vendor/vendor/imports_test.go
@@ -25,8 +25,9 @@ func TestParseImports(t *testing.T) {
 
 func TestFetchMetadata(t *testing.T) {
 	tests := []struct {
-		path string
-		want string
+		path     string
+		want     string
+		insecure bool
 	}{{
 		path: "golang.org/x/tools/cmd/godoc",
 		want: `<!DOCTYPE html>
@@ -58,7 +59,7 @@ go get gopkg.in/check.v1
 	}}
 
 	for _, tt := range tests {
-		r, err := FetchMetadata(tt.path)
+		r, err := FetchMetadata(tt.path, tt.insecure)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -83,6 +84,7 @@ func TestParseMetadata(t *testing.T) {
 		importpath string
 		vcs        string
 		reporoot   string
+		insecure   bool
 	}{{
 		path:       "golang.org/x/tools/cmd/godoc",
 		importpath: "golang.org/x/tools",
@@ -101,7 +103,7 @@ func TestParseMetadata(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		importpath, vcs, reporoot, err := ParseMetadata(tt.path)
+		importpath, vcs, reporoot, err := ParseMetadata(tt.path, tt.insecure)
 		if err != nil {
 			t.Error(err)
 			continue

--- a/cmd/gb-vendor/vendor/repo.go
+++ b/cmd/gb-vendor/vendor/repo.go
@@ -120,7 +120,7 @@ func DeduceRemoteRepo(path string, insecure bool) (RemoteRepo, string, error) {
 	}
 
 	// no idea, try to resolve as a vanity import
-	importpath, vcs, reporoot, err := ParseMetadata(path)
+	importpath, vcs, reporoot, err := ParseMetadata(path, insecure)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
The missing piece

% gb vendor fetch dave.cheney.net/baz
skipping insecure protocol: http://dave.cheney.net/baz?go-get=1
FATAL command "fetch" failed: unable to determine remote metadata protocol
FATAL command "vendor" failed: exit status 1