### PR TITLE
cmd/gb: add experimental depset command and add recursive fetch ability

### DIFF
--- a/cmd/depset.go
+++ b/cmd/depset.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	"fmt"
+	"go/build"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func keys(m map[string]bool) []string {
+	var v []string
+	for k := range m {
+		v = append(v, k)
+	}
+	return v
+}
+
+// Pkg describes a Go package.
+type Pkg struct {
+	*Depset
+	*build.Package
+}
+
+// Depset describes a set of related Go packages.
+type Depset struct {
+	Root   string
+	Prefix string
+	Pkgs   map[string]*Pkg
+}
+
+// LoadPaths returns a map of paths to Depsets.
+func LoadPaths(paths ...struct{ Root, Prefix string }) (map[string]*Depset, error) {
+	m := make(map[string]*Depset)
+	for _, p := range paths {
+		set, err := LoadTree(p.Root, p.Prefix)
+		if err != nil {
+			return nil, err
+		}
+		m[set.Root] = set
+	}
+	return m, nil
+}
+
+// LoadTree parses a tree of source files into a map of *pkgs.
+func LoadTree(root string, prefix string) (*Depset, error) {
+	d := Depset{
+		Root:   root,
+		Prefix: prefix,
+		Pkgs:   make(map[string]*Pkg),
+	}
+	fn := func(dir string, fi os.FileInfo) error {
+		importpath := filepath.Join(prefix, dir[len(root)+1:])
+
+		// if we're at the root of a tree, skip it
+		if importpath == "" {
+			return nil
+		}
+
+		p, err := loadPackage(&d, dir, importpath)
+		if err != nil {
+			if _, ok := err.(*build.NoGoError); ok {
+				return nil
+			}
+			return fmt.Errorf("loadPackage(%q, %q): %v", dir, importpath, err)
+		}
+		p.ImportPath = importpath
+		if p != nil {
+			d.Pkgs[p.ImportPath] = p
+		}
+		return nil
+	}
+
+	// handle root of the tree
+	fi, err := os.Stat(root)
+	if err != nil {
+		return nil, err
+	}
+	if err := fn(root+"/", fi); err != nil {
+		return nil, err
+	}
+
+	// walk sub directories
+	err = eachDir(root, fn)
+	return &d, err
+}
+
+func loadPackage(d *Depset, dir, importpath string) (*Pkg, error) {
+	p := Pkg{
+		Depset: d,
+	}
+	var err error
+
+	// expolit local import logic
+	p.Package, err = build.ImportDir(dir, build.ImportComment)
+	return &p, err
+}
+
+func eachFile(dir string, fn func(string, os.FileInfo) error) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	files, err := f.Readdir(-1)
+	if err != nil {
+		return err
+	}
+	for _, fi := range files {
+		if fi.IsDir() {
+			continue
+		}
+		path := filepath.Join(dir, fi.Name())
+		if err := fn(path, fi); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func eachDir(dir string, fn func(string, os.FileInfo) error) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	files, err := f.Readdir(-1)
+	for _, fi := range files {
+		if !fi.IsDir() {
+			continue
+		}
+		if strings.HasPrefix(fi.Name(), "_") || strings.HasPrefix(fi.Name(), ".") || fi.Name() == "testdata" {
+			continue
+		}
+		path := filepath.Join(dir, fi.Name())
+		if err := fn(path, fi); err != nil {
+			return err
+		}
+		if err := eachDir(path, fn); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/gb-vendor/alldocs.go
+++ b/cmd/gb-vendor/alldocs.go
@@ -28,7 +28,7 @@ Fetch a remote dependency
 
 Usage:
 
-        gb vendor fetch [-branch branch | -revision rev | -tag tag | -precaire] importpath
+        gb vendor fetch [-branch branch | -revision rev | -tag tag] [-precaire] importpath
 
 fetch vendors the upstream import path.
 
@@ -60,7 +60,7 @@ The second restriction is if you have used -tag or -revision while vendoring a d
 (to borrow a term from git) and cannot be updated.
 
 To update across branches, or from one tag/revision to another, you must first use gb vendor delete to remove the dependency, then
-gb vendor fetch [-tag | -revision | -branch] to replace it.
+gb vendor fetch [-tag | -revision | -branch ] [-precaire] to replace it.
 
 Flags:
 	-all

--- a/cmd/gb-vendor/alldocs.go
+++ b/cmd/gb-vendor/alldocs.go
@@ -28,7 +28,7 @@ Fetch a remote dependency
 
 Usage:
 
-        gb vendor fetch [-branch branch | -revision rev | -tag tag] [-precaire] importpath
+        gb vendor fetch [-branch branch | -revision rev | -tag tag] [-precaire] [-no-recurse] importpath
 
 fetch vendors the upstream import path.
 
@@ -36,6 +36,8 @@ Flags:
 	-branch branch
 		fetch from the name branch. If not supplied the default upstream
 		branch will be used.
+	-no-recurse
+		do not fetch recursively.
 	-tag tag
 		fetch the specified tag. If not supplie the default upstream
 		branch will be used.

--- a/cmd/gb-vendor/fetch.go
+++ b/cmd/gb-vendor/fetch.go
@@ -4,6 +4,9 @@ import (
 	"flag"
 	"fmt"
 	"path/filepath"
+	"runtime"
+
+	"go/build"
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
@@ -20,6 +23,7 @@ var (
 
 	tag string
 
+	recurse  bool // should we fetch recursively
 	insecure bool // Allow the use of insecure protocols
 )
 
@@ -27,12 +31,13 @@ func addFetchFlags(fs *flag.FlagSet) {
 	fs.StringVar(&branch, "branch", "", "branch of the package")
 	fs.StringVar(&revision, "revision", "", "revision of the package")
 	fs.StringVar(&tag, "tag", "", "tag of the package")
+	fs.BoolVar(&recurse, "no-recuse", true, "do not fetch recursively")
 	fs.BoolVar(&insecure, "precaire", false, "allow the use of insecure protocols")
 }
 
 var cmdFetch = &cmd.Command{
 	Name:      "fetch",
-	UsageLine: "fetch [-branch branch | -revision rev | -tag tag] [-precaire] importpath",
+	UsageLine: "fetch [-branch branch | -revision rev | -tag tag] [-precaire] [-no-recurse] importpath",
 	Short:     "fetch a remote dependency",
 	Long: `fetch vendors the upstream import path.
 
@@ -40,6 +45,8 @@ Flags:
 	-branch branch
 		fetch from the name branch. If not supplied the default upstream
 		branch will be used.
+	-no-recurse
+		do not fetch recursively.
 	-tag tag
 		fetch the specified tag. If not supplie the default upstream 
 		branch will be used.
@@ -55,59 +62,190 @@ Flags:
 			return fmt.Errorf("fetch: import path missing")
 		}
 		path := args[0]
-
-		m, err := vendor.ReadManifest(manifestFile(ctx))
-		if err != nil {
-			return fmt.Errorf("could not load manifest: %v", err)
-		}
-
-		repo, extra, err := vendor.DeduceRemoteRepo(path, insecure)
-		if err != nil {
-			return err
-		}
-
-		if m.HasImportpath(path) {
-			return fmt.Errorf("%s is already vendored", path)
-		}
-
-		wc, err := repo.Checkout(branch, tag, revision)
-		if err != nil {
-			return err
-		}
-
-		rev, err := wc.Revision()
-		if err != nil {
-			return err
-		}
-
-		branch, err := wc.Branch()
-		if err != nil {
-			return err
-		}
-
-		dep := vendor.Dependency{
-			Importpath: path,
-			Repository: repo.URL(),
-			Revision:   rev,
-			Branch:     branch,
-			Path:       extra,
-		}
-
-		if err := m.AddDependency(dep); err != nil {
-			return err
-		}
-
-		dst := filepath.Join(ctx.Projectdir(), "vendor", "src", dep.Importpath)
-		src := filepath.Join(wc.Dir(), dep.Path)
-
-		if err := vendor.Copypath(dst, src); err != nil {
-			return err
-		}
-
-		if err := vendor.WriteManifest(manifestFile(ctx), m); err != nil {
-			return err
-		}
-		return wc.Destroy()
+		return fetch(ctx, path, recurse)
 	},
 	AddFlags: addFetchFlags,
+}
+
+func fetch(ctx *gb.Context, path string, recurse bool) error {
+	m, err := vendor.ReadManifest(manifestFile(ctx))
+	if err != nil {
+		return fmt.Errorf("could not load manifest: %v", err)
+	}
+
+	repo, extra, err := vendor.DeduceRemoteRepo(path, insecure)
+	if err != nil {
+		return err
+	}
+
+	if m.HasImportpath(path) {
+		return fmt.Errorf("%s is already vendored", path)
+	}
+
+	wc, err := repo.Checkout(branch, tag, revision)
+	if err != nil {
+		return err
+	}
+
+	rev, err := wc.Revision()
+	if err != nil {
+		return err
+	}
+
+	branch, err := wc.Branch()
+	if err != nil {
+		return err
+	}
+
+	dep := vendor.Dependency{
+		Importpath: path,
+		Repository: repo.URL(),
+		Revision:   rev,
+		Branch:     branch,
+		Path:       extra,
+	}
+
+	if err := m.AddDependency(dep); err != nil {
+		return err
+	}
+
+	dst := filepath.Join(ctx.Projectdir(), "vendor", "src", dep.Importpath)
+	src := filepath.Join(wc.Dir(), dep.Path)
+
+	if err := vendor.Copypath(dst, src); err != nil {
+		return err
+	}
+
+	if err := vendor.WriteManifest(manifestFile(ctx), m); err != nil {
+		return err
+	}
+
+	if err := wc.Destroy(); err != nil {
+		return err
+	}
+
+	if !recurse {
+		return nil
+	}
+
+	for done := false; !done; {
+
+		paths := []struct {
+			Root, Prefix string
+		}{
+			{filepath.Join(runtime.GOROOT(), "src"), ""},
+			{filepath.Join(ctx.Projectdir(), "src"), ""},
+		}
+		m, err := vendor.ReadManifest(filepath.Join("vendor", "manifest"))
+		if err != nil {
+			return err
+		}
+		for _, d := range m.Dependencies {
+			paths = append(paths, struct{ Root, Prefix string }{filepath.Join(ctx.Projectdir(), "vendor", "src", filepath.FromSlash(d.Importpath)), filepath.FromSlash(d.Importpath)})
+		}
+
+		dsm, err := cmd.LoadPaths(paths...)
+		if err != nil {
+			return err
+		}
+
+		rs := dsm[path].Pkgs
+
+		missing := findMissing(pkgs(rs), dsm)
+		done = len(missing) == 0
+
+		for pkg := range missing {
+			fmt.Printf("\t%s\n", pkg)
+			if err := fetch(ctx, pkg, false); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func keys(m map[string]bool) []string {
+	var s []string
+	for k := range m {
+		s = append(s, k)
+	}
+	return s
+}
+
+func pkgs(m map[string]*cmd.Pkg) []*cmd.Pkg {
+	var p []*cmd.Pkg
+	for _, v := range m {
+		p = append(p, v)
+	}
+	return p
+}
+
+func findMissing(pkgs []*cmd.Pkg, dsm map[string]*cmd.Depset) map[string]bool {
+	missing := make(map[string]bool)
+	imports := make(map[string]*cmd.Pkg)
+	for _, s := range dsm {
+		for _, p := range s.Pkgs {
+			imports[p.ImportPath] = p
+		}
+	}
+
+	// make fake C package for cgo
+	imports["C"] = &cmd.Pkg{
+		Depset: nil, // probably a bad idea
+		Package: &build.Package{
+			Name: "C",
+		},
+	}
+	stk := make(map[string]bool)
+	push := func(v string) {
+		if stk[v] {
+			panic(fmt.Sprintln("import loop:", v, stk))
+		}
+		stk[v] = true
+	}
+	pop := func(v string) {
+		if !stk[v] {
+			panic(fmt.Sprintln("impossible pop:", v, stk))
+		}
+		delete(stk, v)
+	}
+
+	// checked records import paths who's dependencies are all present
+	checked := make(map[string]bool)
+
+	var fn func(string)
+	fn = func(importpath string) {
+		p, ok := imports[importpath]
+		if !ok {
+			missing[importpath] = true
+			return
+		}
+
+		// have we already walked this arm, if so, skip it
+		if checked[importpath] {
+			return
+		}
+
+		sz := len(missing)
+		push(importpath)
+		for _, i := range p.Imports {
+			if i == importpath {
+				continue
+			}
+			fn(i)
+		}
+
+		// if the size of the missing map has not changed
+		// this entire subtree is complete, mark it as such
+		if len(missing) == sz {
+			checked[importpath] = true
+		}
+		pop(importpath)
+	}
+	for _, pkg := range pkgs {
+		fn(pkg.ImportPath)
+	}
+	return missing
 }

--- a/cmd/gb-vendor/fetch.go
+++ b/cmd/gb-vendor/fetch.go
@@ -32,7 +32,7 @@ func addFetchFlags(fs *flag.FlagSet) {
 
 var cmdFetch = &cmd.Command{
 	Name:      "fetch",
-	UsageLine: "fetch [-branch branch | -revision rev | -tag tag] importpath",
+	UsageLine: "fetch [-branch branch | -revision rev | -tag tag] [-precaire] importpath",
 	Short:     "fetch a remote dependency",
 	Long: `fetch vendors the upstream import path.
 

--- a/cmd/gb-vendor/update.go
+++ b/cmd/gb-vendor/update.go
@@ -34,7 +34,7 @@ The second restriction is if you have used -tag or -revision while vendoring a d
 (to borrow a term from git) and cannot be updated.
 
 To update across branches, or from one tag/revision to another, you must first use gb vendor delete to remove the dependency, then
-gb vendor fetch [-tag | -revision | -branch | -precaire] to replace it.
+gb vendor fetch [-tag | -revision | -branch ] [-precaire] to replace it.
 
 Flags:
 	-all

--- a/cmd/gb/depset.go
+++ b/cmd/gb/depset.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"fmt"
+	"go/build"
+	"path/filepath"
+	"runtime"
+
+	"github.com/constabulary/gb"
+	"github.com/constabulary/gb/cmd"
+	"github.com/constabulary/gb/cmd/gb-vendor/vendor"
+)
+
+func init() {
+	registerCommand(&cmd.Command{
+		Name: "depset",
+		Run:  depset,
+	})
+}
+
+func depset(ctx *gb.Context, args []string) error {
+	paths := []struct {
+		Root, Prefix string
+	}{
+		{filepath.Join(runtime.GOROOT(), "src"), ""},
+		{filepath.Join(ctx.Projectdir(), "src"), ""},
+	}
+	m, err := vendor.ReadManifest(filepath.Join("vendor", "manifest"))
+	if err != nil {
+		return err
+	}
+	for _, d := range m.Dependencies {
+		paths = append(paths, struct{ Root, Prefix string }{filepath.Join(ctx.Projectdir(), "vendor", "src", filepath.FromSlash(d.Importpath)), filepath.FromSlash(d.Importpath)})
+	}
+
+	dsm, err := cmd.LoadPaths(paths...)
+	if err != nil {
+		return err
+	}
+	for _, set := range dsm {
+		fmt.Printf("%s (%s)\n", set.Root, set.Prefix)
+		for _, p := range set.Pkgs {
+			fmt.Printf("\t%s (%s)\n", p.ImportPath, p.Name)
+			fmt.Printf("\t\timports: %s\n", p.Imports)
+		}
+	}
+
+	root := paths[1] // $PROJECT/src
+	rs := dsm[root.Root].Pkgs
+
+	fmt.Println("missing:")
+	for missing := range findMissing(pkgs(rs), dsm) {
+		fmt.Printf("\t%s\n", missing)
+	}
+
+	return nil
+}
+
+func keys(m map[string]bool) []string {
+	var s []string
+	for k := range m {
+		s = append(s, k)
+	}
+	return s
+}
+
+func pkgs(m map[string]*cmd.Pkg) []*cmd.Pkg {
+	var p []*cmd.Pkg
+	for _, v := range m {
+		p = append(p, v)
+	}
+	return p
+}
+
+func findMissing(pkgs []*cmd.Pkg, dsm map[string]*cmd.Depset) map[string]bool {
+	missing := make(map[string]bool)
+	imports := make(map[string]*cmd.Pkg)
+	for _, s := range dsm {
+		for _, p := range s.Pkgs {
+			imports[p.ImportPath] = p
+		}
+	}
+
+	// make fake C package for cgo
+	imports["C"] = &cmd.Pkg{
+		Depset: nil, // probably a bad idea
+		Package: &build.Package{
+			Name: "C",
+		},
+	}
+	stk := make(map[string]bool)
+	push := func(v string) {
+		if stk[v] {
+			panic(fmt.Sprintln("import loop:", v, stk))
+		}
+		stk[v] = true
+	}
+	pop := func(v string) {
+		if !stk[v] {
+			panic(fmt.Sprintln("impossible pop:", v, stk))
+		}
+		delete(stk, v)
+	}
+
+	var fn func(string)
+	fn = func(importpath string) {
+		p, ok := imports[importpath]
+		if !ok {
+			missing[importpath] = true
+			return
+		}
+		push(importpath)
+		for _, i := range p.Imports {
+			if i == importpath {
+				continue
+			}
+			fn(i)
+		}
+		pop(importpath)
+	}
+	for _, pkg := range pkgs {
+		fn(pkg.ImportPath)
+	}
+	return missing
+}

--- a/cmd/gb/stringset.go
+++ b/cmd/gb/stringset.go
@@ -1,0 +1,52 @@
+package main
+
+// union returns the union of a and b.
+func union(a, b map[string]bool) map[string]bool {
+	r := make(map[string]bool)
+	for k := range a {
+		r[k] = true
+	}
+	for k := range b {
+		r[k] = true
+	}
+	return r
+}
+
+// intersection returns the intersection of a and b.
+func intersection(a, b map[string]bool) map[string]bool {
+	r := make(map[string]bool)
+	for k := range a {
+		if b[k] {
+			r[k] = true
+		}
+	}
+	return r
+}
+
+// difference returns the symetric difference of a and b.
+func difference(a, b map[string]bool) map[string]bool {
+	r := make(map[string]bool)
+	for k := range a {
+		if !b[k] {
+			r[k] = true
+		}
+	}
+	for k := range b {
+		if !a[k] {
+			r[k] = true
+		}
+	}
+	return r
+}
+
+// contains returns true if a contains all the elements in s.
+func contains(a map[string]bool, s ...string) bool {
+	var r bool
+	for _, e := range s {
+		if !a[e] {
+			return false
+		}
+		r = true
+	}
+	return r
+}

--- a/cmd/gb/stringset_test.go
+++ b/cmd/gb/stringset_test.go
@@ -1,0 +1,147 @@
+package main
+
+import "testing"
+import "reflect"
+
+func set(args ...string) map[string]bool {
+	r := make(map[string]bool)
+	for _, a := range args {
+		r[a] = true
+	}
+	return r
+}
+
+func TestUnion(t *testing.T) {
+	tests := []struct {
+		a, b map[string]bool
+		want map[string]bool
+	}{{
+		a: nil, b: nil,
+		want: set(),
+	}, {
+		a: nil, b: set("b"),
+		want: set("b"),
+	}, {
+		a: set("a"), b: nil,
+		want: set("a"),
+	}, {
+		a: set("a"), b: set("b"),
+		want: set("b", "a"),
+	}, {
+		a: set("c"), b: set("c"),
+		want: set("c"),
+	}}
+
+	for _, tt := range tests {
+		got := union(tt.a, tt.b)
+		if !reflect.DeepEqual(tt.want, got) {
+			t.Errorf("union(%v, %v) want: %v, got %v", tt.a, tt.b, tt.want, got)
+		}
+	}
+}
+
+func TestIntersection(t *testing.T) {
+	tests := []struct {
+		a, b map[string]bool
+		want map[string]bool
+	}{{
+		a: nil, b: nil,
+		want: set(),
+	}, {
+		a: nil, b: set("b"),
+		want: set(),
+	}, {
+		a: set("a"), b: nil,
+		want: set(),
+	}, {
+		a: set("a"), b: set("b"),
+		want: set(),
+	}, {
+		a: set("c"), b: set("c"),
+		want: set("c"),
+	}, {
+		a: set("a", "c"), b: set("b", "c"),
+		want: set("c"),
+	}}
+
+	for _, tt := range tests {
+		got := intersection(tt.a, tt.b)
+		if !reflect.DeepEqual(tt.want, got) {
+			t.Errorf("intersection(%v, %v) want: %v, got %v", tt.a, tt.b, tt.want, got)
+		}
+	}
+}
+
+func TestDifference(t *testing.T) {
+	tests := []struct {
+		a, b map[string]bool
+		want map[string]bool
+	}{{
+		a: nil, b: nil,
+		want: set(),
+	}, {
+		a: nil, b: set("b"),
+		want: set("b"),
+	}, {
+		a: set("a"), b: nil,
+		want: set("a"),
+	}, {
+		a: set("a"), b: set("b"),
+		want: set("a", "b"),
+	}, {
+		a: set("c"), b: set("c"),
+		want: set(),
+	}, {
+		a: set("a", "c"), b: set("b", "c"),
+		want: set("a", "b"),
+	}}
+
+	for _, tt := range tests {
+		got := difference(tt.a, tt.b)
+		if !reflect.DeepEqual(tt.want, got) {
+			t.Errorf("difference(%v, %v) want: %v, got %v", tt.a, tt.b, tt.want, got)
+		}
+	}
+}
+
+func TestContains(t *testing.T) {
+	tests := []struct {
+		a    map[string]bool
+		s    []string
+		want bool
+	}{{
+		a: nil, s: nil,
+		want: false,
+	}, {
+		a: set("a"), s: nil,
+		want: false,
+	}, {
+		a: set("a"), s: []string{"a"},
+		want: true,
+	}, {
+		a: set("a"), s: []string{"b"},
+		want: false,
+	}, {
+		a: set("a", "b"), s: []string{"b"},
+		want: true,
+	}, {
+		a: set("a"), s: []string{"a", "b"},
+		want: false,
+	}, {
+		a: set("a", "b", "c"), s: []string{"a", "b"},
+		want: true,
+	}, {
+		a: set("a", "b", "c"), s: []string{"x", "b"},
+		want: false,
+	}, {
+		a: set("a", "b", "c"), s: []string{"b", "c", "d"},
+		want: false,
+	}}
+
+	for _, tt := range tests {
+		got := contains(tt.a, tt.s...)
+		if !reflect.DeepEqual(tt.want, got) {
+			t.Errorf("contains(%v, %v) want: %v, got %v", tt.a, tt.s, tt.want, got)
+		}
+	}
+}


### PR DESCRIPTION
depset is an experimental command to explore analysing dependency sets.
It produces output like this, http://paste.ubuntu.com/11739677/

At the moment it has worse than quadratic behaviour, making it unsuitable for anything serious.

The goal of depset is to develop a set of functions in the `cmd` package that can be used by tools like `gb-vendor` to analyse dependencies as a set rather than as individual imports.
Dependency sets are groups of packages that are related by being children of a single source root. A canonical example of a source root is $GOPATH/src, another is $PROJECT/src. However we can be smarter and create sets for each vendored import tree, which in turn allows us to determine which dependencies are no longer referenced with more accuracy than the current gb vendor purge command.

Another function of dep sets is to determine missing packages, the output of which could be fed back into gb vendor fetch to drive recursive depdendency fetching.

/cc @davidkaya 