### PR TITLE
cmd/gb: add -gcflags to build flags

### DIFF
--- a/build.go
+++ b/build.go
@@ -254,7 +254,7 @@ func (l *ld) link() error {
 		includes = append([]string{l.pkg.ExtraIncludes}, includes...)
 		target += ".test"
 	}
-	err := l.pkg.tc.Ld(l.pkg, includes, l.pkg.ldflags, target, l.afile.Pkgfile())
+	err := l.pkg.tc.Ld(l.pkg, includes, target, l.afile.Pkgfile())
 	l.pkg.Record("link", time.Since(t0))
 	return err
 }

--- a/cmd/gb/build.go
+++ b/cmd/gb/build.go
@@ -29,7 +29,7 @@ var (
 	// skip caching of packages
 	FF bool
 
-	ldflags string
+	ldflags, gcflags string
 )
 
 func addBuildFlags(fs *flag.FlagSet) {
@@ -39,6 +39,7 @@ func addBuildFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&F, "f", false, "rebuild up to date packages")
 	fs.BoolVar(&FF, "F", false, "do not cache built packages")
 	fs.StringVar(&ldflags, "ldflags", "", "flags passed to the linker")
+	fs.StringVar(&gcflags, "gcflags", "", "flags passed to the compiler")
 }
 
 var BuildCmd = &cmd.Command{
@@ -65,6 +66,8 @@ The build flags are
 		increases verbosity, effectively lowering the output level from INFO to DEBUG.
 	-ldflags 'flag list'
 		arguments to pass on each linker invocation.
+	-gcflags 'arg list'
+		arguments to pass on each go tool compile invocation.
 
 The list flags accept a space-separated list of strings. To embed spaces in an element in the list, surround it with either single or double quotes.
 

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -84,6 +84,7 @@ func main() {
 
 	ctx, err := project.NewContext(
 		gb.GcToolchain(),
+		gb.Gcflags(gcflags),
 		gb.Ldflags(ldflags),
 	)
 	if err != nil {

--- a/context.go
+++ b/context.go
@@ -32,6 +32,7 @@ type Context struct {
 
 	permits chan bool // used to limit concurrency of Run targets
 
+	gcflags []string // flags passed to the compiler
 	ldflags []string // flags passed to the linker
 }
 
@@ -52,6 +53,15 @@ func (p *Project) NewContext(opts ...func(*Context) error) (*Context, error) {
 		}
 	}
 	return ctx, nil
+}
+
+// Gcflags sets options passed to the compiler.
+func Gcflags(flags string) func(*Context) error {
+	return func(c *Context) error {
+		var err error
+		c.gcflags, err = splitQuotedFields(flags)
+		return err
+	}
 }
 
 // Ldflags sets options passed to the linker.

--- a/gb.go
+++ b/gb.go
@@ -19,7 +19,7 @@ type Toolchain interface {
 	Gc(pkg *Package, searchpaths []string, importpath, srcdir, outfile string, files []string, complete bool) error
 	Asm(pkg *Package, srcdir, ofile, sfile string) error
 	Pack(pkg *Package, afiles ...string) error
-	Ld(*Package, []string, []string, string, string) error
+	Ld(*Package, []string, string, string) error
 	Cc(pkg *Package, ofile string, cfile string) error
 
 	// compiler returns the location of the compiler for .go source code

--- a/gc14.go
+++ b/gc14.go
@@ -5,6 +5,7 @@ package gb
 import (
 	"fmt"
 	"go/build"
+	"os"
 	"path/filepath"
 	"runtime"
 )
@@ -48,7 +49,7 @@ func GcToolchain(opts ...func(*gcoption)) func(c *Context) error {
 func (t *gcToolchain) Gc(pkg *Package, searchpaths []string, importpath, srcdir, outfile string, files []string, complete bool) error {
 	Debugf("gc:gc %v %v %v %v", importpath, srcdir, outfile, files)
 
-	args := []string{"-p", importpath, "-pack"}
+	args := append(pkg.gcflags, "-p", importpath, "-pack")
 	args = append(args, "-o", outfile)
 	for _, d := range searchpaths {
 		args = append(args, "-I", d)
@@ -60,7 +61,7 @@ func (t *gcToolchain) Gc(pkg *Package, searchpaths []string, importpath, srcdir,
 	if err := mkdir(filepath.Dir(outfile)); err != nil {
 		return fmt.Errorf("gc:gc: %v", err)
 	}
-	return pkg.run(srcdir, nil, t.gc, args...)
+	return pkg.runOut(os.Stdout, srcdir, nil, t.gc, args...)
 }
 
 func (t *gcToolchain) Asm(pkg *Package, srcdir, ofile, sfile string) error {
@@ -72,8 +73,8 @@ func (t *gcToolchain) Asm(pkg *Package, srcdir, ofile, sfile string) error {
 	return pkg.run(srcdir, nil, t.as, args...)
 }
 
-func (t *gcToolchain) Ld(pkg *Package, searchpaths, ldflags []string, outfile, afile string) error {
-	args := append(ldflags, "-o", outfile)
+func (t *gcToolchain) Ld(pkg *Package, searchpaths, outfile, afile string) error {
+	args := append(pkg.Ldflags, "-o", outfile)
 	for _, d := range searchpaths {
 		args = append(args, "-L", d)
 	}

--- a/gc14.go
+++ b/gc14.go
@@ -74,7 +74,7 @@ func (t *gcToolchain) Asm(pkg *Package, srcdir, ofile, sfile string) error {
 }
 
 func (t *gcToolchain) Ld(pkg *Package, searchpaths []string, outfile, afile string) error {
-	args := append(pkg.Ldflags, "-o", outfile)
+	args := append(pkg.ldflags, "-o", outfile)
 	for _, d := range searchpaths {
 		args = append(args, "-L", d)
 	}

--- a/gc14.go
+++ b/gc14.go
@@ -73,7 +73,7 @@ func (t *gcToolchain) Asm(pkg *Package, srcdir, ofile, sfile string) error {
 	return pkg.run(srcdir, nil, t.as, args...)
 }
 
-func (t *gcToolchain) Ld(pkg *Package, searchpaths, outfile, afile string) error {
+func (t *gcToolchain) Ld(pkg *Package, searchpaths []string, outfile, afile string) error {
 	args := append(pkg.Ldflags, "-o", outfile)
 	for _, d := range searchpaths {
 		args = append(args, "-L", d)

--- a/gc15.go
+++ b/gc15.go
@@ -4,6 +4,7 @@ package gb
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 )
@@ -42,7 +43,7 @@ func GcToolchain(opts ...func(*gcoption)) func(c *Context) error {
 }
 
 func (t *gcToolchain) Gc(pkg *Package, searchpaths []string, importpath, srcdir, outfile string, files []string, complete bool) error {
-	args := []string{"-p", importpath, "-pack"}
+	args := append(pkg.gcflags, "-p", importpath, "-pack")
 	args = append(args, "-o", outfile)
 	for _, d := range searchpaths {
 		args = append(args, "-I", d)
@@ -54,7 +55,7 @@ func (t *gcToolchain) Gc(pkg *Package, searchpaths []string, importpath, srcdir,
 	if err := mkdir(filepath.Dir(outfile)); err != nil {
 		return fmt.Errorf("gc:gc: %v", err)
 	}
-	return pkg.run(srcdir, nil, t.gc, args...)
+	return pkg.runOut(os.Stdout, srcdir, nil, t.gc, args...)
 }
 
 func (t *gcToolchain) Asm(pkg *Package, srcdir, ofile, sfile string) error {
@@ -66,8 +67,8 @@ func (t *gcToolchain) Asm(pkg *Package, srcdir, ofile, sfile string) error {
 	return pkg.run(srcdir, nil, t.as, args...)
 }
 
-func (t *gcToolchain) Ld(pkg *Package, searchpaths, ldflags []string, outfile, afile string) error {
-	args := append(ldflags, "-o", outfile)
+func (t *gcToolchain) Ld(pkg *Package, searchpaths []string, outfile, afile string) error {
+	args := append(pkg.ldflags, "-o", outfile)
 	for _, d := range searchpaths {
 		args = append(args, "-L", d)
 	}


### PR DESCRIPTION
Fixes #240

Sample usage:

    gb build -gcflags=-m