### PR TITLE
gb vendor list: use tabwriter to format output

### DIFF
--- a/cmd/gb-vendor/list.go
+++ b/cmd/gb-vendor/list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html/template"
 	"os"
+	"text/tabwriter"
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
@@ -36,14 +37,14 @@ Flags:
 		if err != nil {
 			return fmt.Errorf("unable to parse template %q: %v", format, err)
 		}
-
+		w := tabwriter.NewWriter(os.Stdout, 1, 2, 1, ' ', 0)
 		for _, dep := range m.Dependencies {
-			if err := tmpl.Execute(os.Stdout, dep); err != nil {
+			if err := tmpl.Execute(w, dep); err != nil {
 				return fmt.Errorf("unable to execute template: %v", err)
 			}
-			fmt.Fprintln(os.Stdout)
+			fmt.Fprintln(w)
 		}
-		return nil
+		return w.Flush()
 	},
 	AddFlags: func(fs *flag.FlagSet) {
 		fs.StringVar(&format, "f", "{{.Importpath}}\t{{.Repository}}{{.Path}}\t{{.Branch}}\t{{.Revision}}", "format template")


### PR DESCRIPTION
Hey,

I piped the output from `gb vendor list` through `text/tabwriter` to make it more readable. I can hide it behind a flag if preferred.

Before:
![gbvendorlist_before](https://cloud.githubusercontent.com/assets/111202/8498996/f46841da-218d-11e5-9cd3-222f4ee47aff.png)

After:
![gbvendorlist_after](https://cloud.githubusercontent.com/assets/111202/8498998/f6f994b2-218d-11e5-8cb4-7a6a5b93d800.png)

