### PR TITLE
Check output instead of exit status for git ls-remote

### DIFF
--- a/cmd/gb-vendor/vendor/repo.go
+++ b/cmd/gb-vendor/vendor/repo.go
@@ -163,7 +163,8 @@ func probeGitUrl(schemes []string, host, path string, insecure bool) (string, er
 		switch scheme {
 		case "https":
 			url := scheme + "://" + host + "/" + path
-			if _, err := run("git", "ls-remote", "--exit-code", url, "HEAD"); err == nil {
+			out, err := run("git", "ls-remote", url, "HEAD")
+			if err == nil && bytes.Contains(out, []byte("HEAD")) {
 				return url, nil
 			}
 		case "http", "git":
@@ -171,7 +172,8 @@ func probeGitUrl(schemes []string, host, path string, insecure bool) (string, er
 			if !insecure {
 				gb.Infof("skipping insecure protocol: %v", url)
 			} else {
-				if _, err := run("git", "ls-remote", "--exit-code", url, "HEAD"); err == nil {
+				out, err := run("git", "ls-remote", url, "HEAD")
+				if err == nil && bytes.Contains(out, []byte("HEAD")) {
 					return url, nil
 				}
 			}


### PR DESCRIPTION
git 1.7.1 (Used by RHEL 6) does not have the --exit-code option
so gb vendor fetch fails, this changes the test to do a simple
check for the string "HEAD" in the output instead.