### PR TITLE
Issue 

### DIFF
--- a/cmd/testflag.go
+++ b/cmd/testflag.go
@@ -18,8 +18,8 @@ type testFlagSpec struct {
 // testFlagDefn is the set of flags we process.
 var testFlagDefn = map[string]*testFlagSpec{
 	// local to the test plugin
-	"q":         {boolVar: true, passToAll: true},
-	"v":         {boolVar: true, passToAll: true},
+	"q":         {boolVar: true, passToTest: true, passToAll: true},
+	"v":         {boolVar: true, passToTest: true, passToAll: true},
 	"cover":     {boolVar: true},
 	"coverpkg":  {},
 	"covermode": {},

--- a/cmd/testflag.go
+++ b/cmd/testflag.go
@@ -18,13 +18,13 @@ type testFlagSpec struct {
 // testFlagDefn is the set of flags we process.
 var testFlagDefn = map[string]*testFlagSpec{
 	// local to the test plugin
-	"q":         {boolVar: true, passToTest: true, passToAll: true},
-	"v":         {boolVar: true, passToTest: true, passToAll: true},
 	"cover":     {boolVar: true},
 	"coverpkg":  {},
 	"covermode": {},
 
 	// Passed to the test binary
+	"q":                {boolVar: true, passToTest: true},
+	"v":                {boolVar: true, passToTest: true},
 	"bench":            {passToTest: true},
 	"benchmem":         {boolVar: true, passToTest: true},
 	"benchtime":        {passToTest: true},

--- a/cmd/testflag_test.go
+++ b/cmd/testflag_test.go
@@ -15,15 +15,14 @@ func TestTestFlagsPreParse(t *testing.T) {
 	}{
 		{
 			args:  []string{"-q", "-test", "-debug"},
-			pargs: []string{"-q"},
 			eargs: []string{"-q", "-test", "-debug"},
 		}, {
 			args:  []string{"-v", "-debug", "package_name"},
-			pargs: []string{"-v", "package_name"},
+			pargs: []string{"package_name"},
 			eargs: []string{"-v", "-debug"},
 		}, {
 			args:  []string{"-q", "-debug", "package_name"},
-			pargs: []string{"-q", "package_name"},
+			pargs: []string{"package_name"},
 			eargs: []string{"-q", "-debug"},
 		}, {
 			args:  []string{"-bench"},


### PR DESCRIPTION
This fixes #216 by making `gb test -v` return correct verbose output without extra debug info.  

Here is some output for these sample tests:
```
package hi

import (
	"testing"
)

func TestSuccess(t *testing.T) {
	t.Log("Success!")
}

func TestFailure(t *testing.T) {
	t.Error("Fail!")
}
```

Before this change:
```
$ gb test -v
DEBUG project root "/home/ryan/.gvm/pkgsets/go1.4rc2/global/src/github.com/constabulary/test"
DEBUG matchPackages: /home/ryan/.gvm/pkgsets/go1.4rc2/global/src/github.com/constabulary/test/src ...
DEBUG args: [hi]
DEBUG loadPackage: hi true (/home/ryan/.gvm/pkgsets/go1.4rc2/global/src/github.com/constabulary/test/src/hi)
DEBUG loadPackage: testing true (/home/ryan/.gvm/gos/go1.4rc2/src/testing)
DEBUG {hi hi /home/ryan/.gvm/pkgsets/go1.4rc2/global/src/github.com/constabulary/test/src/hi} is test scoped, not installing
DEBUG loadTestFuncs: [hi_test.go], []
DEBUG {hi hi/testmain /tmp/gb153125905/hi/_test} is test scoped, not installing
DEBUG scheduling run of [/tmp/gb153125905/hi/testmain/_test/hi.test -test.v]
DEBUG gc:gc hi /home/ryan/.gvm/pkgsets/go1.4rc2/global/src/github.com/constabulary/test /tmp/gb153125905/hi/_test/hi.a [src/hi/hi.go src/hi/hi_test.go]
DEBUG cd /home/ryan/.gvm/pkgsets/go1.4rc2/global/src/github.com/constabulary/test; [/home/ryan/.gvm/gos/go1.4rc2/pkg/tool/linux_amd64/6g -p hi -pack -o /tmp/gb153125905/hi/_test/hi.a -I /tmp/gb153125905 -I /home/ryan/.gvm/pkgsets/go1.4rc2/global/src/github.com/constabulary/test/pkg/linux/amd64 -complete src/hi/hi.go src/hi/hi_test.go]
DEBUG gc:gc hi/testmain /home/ryan/.gvm/pkgsets/go1.4rc2/global/src/github.com/constabulary/test /tmp/gb153125905/hi/testmain/_test/hi/testmain.a [../../../../../../../../../../tmp/gb153125905/hi/_test/_testmain.go]
DEBUG cd /home/ryan/.gvm/pkgsets/go1.4rc2/global/src/github.com/constabulary/test; [/home/ryan/.gvm/gos/go1.4rc2/pkg/tool/linux_amd64/6g -p hi/testmain -pack -o /tmp/gb153125905/hi/testmain/_test/hi/testmain.a -I /tmp/gb153125905/hi/_test -I /tmp/gb153125905 -I /home/ryan/.gvm/pkgsets/go1.4rc2/global/src/github.com/constabulary/test/pkg/linux/amd64 -complete ../../../../../../../../../../tmp/gb153125905/hi/_test/_testmain.go]
DEBUG cd .; [/home/ryan/.gvm/gos/go1.4rc2/pkg/tool/linux_amd64/6l -o /tmp/gb153125905/hi/testmain/_test/hi.test -L /tmp/gb153125905/hi/_test -L /tmp/gb153125905 -L /home/ryan/.gvm/pkgsets/go1.4rc2/global/src/github.com/constabulary/test/pkg/linux/amd64 -extld=gcc /tmp/gb153125905/hi/testmain/_test/hi/testmain.a]
DEBUG run [/tmp/gb153125905/hi/testmain/_test/hi.test -test.v]
=== RUN TestSuccess
--- PASS: TestSuccess (0.00s)
	hi_test.go:8: Success!
=== RUN TestFailure
--- FAIL: TestFailure (0.00s)
	hi_test.go:12: Fail!
FAIL
DEBUG test duration: 211.827632ms map[compile:22.432854ms link:184.906166ms]
FATAL command "test" failed: run [/tmp/gb153125905/hi/testmain/_test/hi.test -test.v]: exit status 1
```

After this change:
```
$ gb test -v
=== RUN TestSuccess
--- PASS: TestSuccess (0.00s)
	hi_test.go:8: Success!
=== RUN TestFailure
--- FAIL: TestFailure (0.00s)
	hi_test.go:12: Fail!
FAIL
FATAL command "test" failed: run [/tmp/gb585619063/hi/testmain/_test/hi.test -test.v]: exit status 1
```