### PR TITLE
slightly improved output when running gb-vendor directly

### DIFF
--- a/cmd/gb-vendor/main.go
+++ b/cmd/gb-vendor/main.go
@@ -31,13 +31,6 @@ var commands = []*cmd.Command{
 }
 
 func main() {
-	root, err := cmd.FindProjectroot(projectroot)
-	if err != nil {
-		gb.Fatalf("could not locate project root: %v", err)
-	}
-	project := gb.NewProject(root)
-	gb.Debugf("project root %q", project.Projectdir())
-
 	args := os.Args[1:]
 	if len(args) < 1 || args[0] == "-h" {
 		fs.Usage()
@@ -48,6 +41,13 @@ func main() {
 		help(args[1:])
 		return
 	}
+
+	root, err := cmd.FindProjectroot(projectroot)
+	if err != nil {
+		gb.Fatalf("could not locate project root: %v", err)
+	}
+	project := gb.NewProject(root)
+	gb.Debugf("project root %q", project.Projectdir())
 
 	for _, command := range commands {
 		if command.Name == args[0] && command.Runnable() {

--- a/cmd/gb-vendor/main.go
+++ b/cmd/gb-vendor/main.go
@@ -32,14 +32,18 @@ var commands = []*cmd.Command{
 
 func main() {
 	args := os.Args[1:]
-	if len(args) < 1 || args[0] == "-h" || args[0] == "-help" {
+
+	switch {
+	case len(args) < 1, args[0] == "-h", args[0] == "-help":
 		fs.Usage()
 		os.Exit(1)
-	}
-
-	if args[0] == "help" {
+	case projectroot == "":
+		gb.Warnf("don't run this binary directly, it is meant to be run as 'gb vendor ...'")
+		gb.Fatalf("expected GB_PROJECT_DIR environment variable")
+	case args[0] == "help":
 		help(args[1:])
 		return
+	default:
 	}
 
 	root, err := cmd.FindProjectroot(projectroot)

--- a/cmd/gb-vendor/main.go
+++ b/cmd/gb-vendor/main.go
@@ -38,8 +38,7 @@ func main() {
 		fs.Usage()
 		os.Exit(1)
 	case projectroot == "":
-		gb.Warnf("don't run this binary directly, it is meant to be run as 'gb vendor ...'")
-		gb.Fatalf("expected GB_PROJECT_DIR environment variable")
+		gb.Fatalf("don't run this binary directly, it is meant to be run as 'gb vendor ...'")
 	case args[0] == "help":
 		help(args[1:])
 		return

--- a/cmd/gb-vendor/main.go
+++ b/cmd/gb-vendor/main.go
@@ -32,7 +32,7 @@ var commands = []*cmd.Command{
 
 func main() {
 	args := os.Args[1:]
-	if len(args) < 1 || args[0] == "-h" {
+	if len(args) < 1 || args[0] == "-h" || args[0] == "-help" {
 		fs.Usage()
 		os.Exit(1)
 	}

--- a/cmd/gb-vendor/main.go
+++ b/cmd/gb-vendor/main.go
@@ -37,11 +37,11 @@ func main() {
 	case len(args) < 1, args[0] == "-h", args[0] == "-help":
 		fs.Usage()
 		os.Exit(1)
-	case projectroot == "":
-		gb.Fatalf("don't run this binary directly, it is meant to be run as 'gb vendor ...'")
 	case args[0] == "help":
 		help(args[1:])
 		return
+	case projectroot == "":
+		gb.Fatalf("don't run this binary directly, it is meant to be run as 'gb vendor ...'")
 	default:
 	}
 


### PR DESCRIPTION
My instinct after go get'ing stuff is to run '-help' on all the binaries that appeared that I didn't expect. In the case of gb-vendor, that resulted in some confusing output about 'project root'. 

I would have found the usage text much more useful as it starts with 'gb vendor', immediately suggesting that gb-vendor is run by the gb command and shouldn't be run by hand.

This patch is purely cosmetic.