### PR TITLE
cmd/gb: add gb info subcommand

### DIFF
--- a/cmd/gb/alldocs.go
+++ b/cmd/gb/alldocs.go
@@ -14,6 +14,7 @@ The commands are:
         doc         show documentation for a package or symbol
         env         print project environment variables
         generate    generate Go files by processing source
+        info        info returns information about this project
         list        list the packages named by the importpaths
         plugin      run a plugin
         test        test packages
@@ -53,10 +54,19 @@ The build flags are
 		increases verbosity, effectively lowering the output level from INFO to DEBUG.
 	-ldflags 'flag list'
 		arguments to pass on each linker invocation.
+	-gcflags 'arg list'
+		arguments to pass on each go tool compile invocation.
 
 The list flags accept a space-separated list of strings. To embed spaces in an element in the list, surround it with either single or double quotes.
 
 For more about specifying packages, see 'gb help packages'. For more about where packages and binaries are installed, run 'gb help project'.
+
+
+Usage:
+
+        gb
+
+
 
 
 Show documentation for a package or symbol
@@ -88,6 +98,17 @@ Those commands can run any process but the intent is to create or update Go
 source files, for instance by running yacc.
 
 See 'go help generate'
+
+
+Info returns information about this project
+
+Usage:
+
+        gb info
+
+info returns information about this project.
+
+info returns 0 if the project is well formed, and non zero otherwise.
 
 
 List the packages named by the importpaths

--- a/cmd/gb/info.go
+++ b/cmd/gb/info.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/constabulary/gb"
+	"github.com/constabulary/gb/cmd"
+)
+
+func init() {
+	registerCommand(&cmd.Command{
+		Name:      "info",
+		UsageLine: `info`,
+		Short:     "info returns information about this project",
+		Long: `info returns information about this project.
+
+info returns 0 if the project is well formed, and non zero otherwise.
+`,
+		Run: info,
+	})
+}
+
+func info(ctx *gb.Context, args []string) error {
+	fmt.Printf("GB_PROJECT_DIR=%q\n", ctx.Projectdir())
+	fmt.Printf("GB_SRC_PATH=%q\n", joinlist(ctx.Srcdirs()...))
+	return nil
+}
+
+// joinlist joins path elements using the os specific separator.
+// TODO(dfc) it probably gets this wrong on windows in some circumstances.
+func joinlist(paths ...string) string {
+	return strings.Join(paths, string(filepath.ListSeparator))
+}


### PR DESCRIPTION
Fixes #267

This PR adds a new subcommand, `info`. This returns some (hopefully) pertinent
information about the project, and an error code to indicate if the path is part
of a gb project or not.

	zapf(~/devel/demo4) % gb info
	GB_PROJECT_DIR="/Users/dfc/devel/demo4"
	GB_SRC_PATH="/Users/dfc/devel/demo4/src:/Users/dfc/devel/demo4/vendor/src"
	zapf(~/devel/demo4) % echo $?
	0

	zapf(~/devel/demo9) % gb info
	FATAL could not locate project root: could not find project root in "/Users/dfc/devel/demo9" or its parents
	zapf(~/devel/demo9) % echo $?                                                                         
    1