### PR TITLE
gb: NewProject now takes SourceDir options

### DIFF
--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -78,7 +78,11 @@ func main() {
 	if err != nil {
 		gb.Fatalf("could not locate project root: %v", err)
 	}
-	project := gb.NewProject(root)
+
+	project := gb.NewProject(root,
+		gb.SourceDir(filepath.Join(root, "src")),
+		gb.SourceDir(filepath.Join(root, "vendor", "src")),
+	)
 
 	gb.Debugf("project root %q", project.Projectdir())
 

--- a/cmd/resolve_test.go
+++ b/cmd/resolve_test.go
@@ -41,7 +41,9 @@ func getwd(t *testing.T) string {
 func testProject(t *testing.T) *gb.Project {
 	cwd := getwd(t)
 	root := filepath.Join(cwd, "..", "testdata")
-	return gb.NewProject(root)
+	return gb.NewProject(root,
+		gb.SourceDir(filepath.Join(root, "src")),
+	)
 }
 
 func testContext(t *testing.T, opts ...func(*gb.Context) error) *gb.Context {

--- a/context.go
+++ b/context.go
@@ -40,6 +40,10 @@ type Context struct {
 // By default this context will use the gc toolchain with the
 // host's GOOS and GOARCH values.
 func (p *Project) NewContext(opts ...func(*Context) error) (*Context, error) {
+	if len(p.srcdirs) == 0 {
+		return nil, fmt.Errorf("no source directories supplied")
+	}
+
 	bc := build.Default
 	bc.GOPATH = togopath(p.Srcdirs())
 	defaults := []func(*Context) error{

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,31 @@
+package gb_test
+
+import (
+	"github.com/constabulary/gb"
+	"log"
+	"path/filepath"
+)
+
+func ExampleNewPackage() {
+
+	// Every project begins with a project root.
+	// Normally you'd check this out of source control.
+	root := filepath.Join("home", "dfc", "devel", "demo")
+
+	// Create a new Project passing in the source directories
+	// under this project's root.
+	proj := gb.NewProject(root,
+		gb.SourceDir(filepath.Join(root, "src")),           // $PROJECT/src
+		gb.SourceDir(filepath.Join(root, "vendor", "src")), // $PROJECT/vendor/src
+	)
+
+	// Create a new Context from the Project. A Context holds
+	// the state of a specific compilation or test within the Project.
+	ctx, err := proj.NewContext()
+	if err != nil {
+		log.Fatal("Could not create new context:", err)
+	}
+
+	// Always remember to clean up your Context
+	ctx.Destroy()
+}

--- a/package_test.go
+++ b/package_test.go
@@ -12,7 +12,9 @@ func testProject(t *testing.T) *Project {
 		t.Fatal(err)
 	}
 	root := filepath.Join(cwd, "testdata")
-	return NewProject(root)
+	return NewProject(root,
+		SourceDir(filepath.Join(root, "src")),
+	)
 }
 
 func testContext(t *testing.T) *Context {

--- a/project.go
+++ b/project.go
@@ -26,14 +26,22 @@ func togopath(srcdirs []string) string {
 	return joinlist(s)
 }
 
-func NewProject(root string) *Project {
-	return &Project{
-		rootdir: root,
-		srcdirs: []Srcdir{
-			{Root: filepath.Join(root, "src")},
-			{Root: filepath.Join(root, "vendor", "src")},
-		},
+func SourceDir(root string) func(*Project) {
+	return func(p *Project) {
+		p.srcdirs = append(p.srcdirs, Srcdir{Root: root})
 	}
+}
+
+func NewProject(root string, options ...func(*Project)) *Project {
+	proj := Project{
+		rootdir: root,
+	}
+
+	for _, opt := range options {
+		opt(&proj)
+	}
+
+	return &proj
 }
 
 // Pkgdir returns the path to precompiled packages.


### PR DESCRIPTION
Fixes #268

This PR adds a feature request from GopherCon to allow users with, uh, unique,
project layouts to construct them manually. The layout that was previously fixed
in `NewProject`, is now moved to `cmd/gb`.

`cmd/gb` will always mandate the traditional `$PROJECT/src`, `$PROJECT/vendor/src` pair, but
users can fork `cmd/gb` and build their own tool if they need more control.