### PR TITLE
Initial support for caching main packages

### DIFF
--- a/build.go
+++ b/build.go
@@ -54,7 +54,7 @@ func BuildDependencies(targets map[string]PkgTarget, pkg *Package) []Target {
 // Compile returns a Target representing all the steps required to build a go package.
 func Compile(pkg *Package, deps ...Target) PkgTarget {
 	if !pkg.Stale {
-		return cachedPackage(pkg)
+		return &cachedPackage{pkg: pkg}
 	}
 	var gofiles []string
 	gofiles = append(gofiles, pkg.GoFiles...)

--- a/build.go
+++ b/build.go
@@ -293,6 +293,13 @@ func objname(pkg *Package) string {
 	}
 }
 
+func pkgname(pkg *Package) string {
+	if pkg.isMain() {
+		return filepath.Base(filepath.FromSlash(pkg.ImportPath))
+	}
+	return pkg.Name
+}
+
 // Binfile returns the destination of the compiled target of this command.
 // TODO(dfc) this should be Target.
 func (pkg *Package) Binfile() string {

--- a/build.go
+++ b/build.go
@@ -268,6 +268,9 @@ func (l *ld) link() error {
 // Ld returns a Target representing the result of linking a
 // Package into a command with the Context provided linker.
 func Ld(pkg *Package, afile PkgTarget) Target {
+	if !pkg.Stale {
+		return &cachedTarget{target: afile}
+	}
 	ld := ld{
 		pkg:   pkg,
 		afile: afile,

--- a/build_test.go
+++ b/build_test.go
@@ -57,6 +57,32 @@ func TestBuild(t *testing.T) {
 	}
 }
 
+func TestPkgname(t *testing.T) {
+	tests := []struct {
+		pkg  string
+		name string
+	}{{
+		pkg:  "a",
+		name: "a",
+	}, {
+		pkg:  "b",
+		name: "b",
+	}}
+
+	ctx := testContext(t)
+	for _, tt := range tests {
+		pkg, err := ctx.ResolvePackage(tt.pkg)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		if got, want := pkgname(pkg), tt.name; got != want {
+			t.Errorf("pkgname(%v): want %v, got %v", want, got)
+		}
+	}
+	ctx.Destroy()
+}
+
 func sameErr(e1, e2 error) bool {
 	if e1 != nil && e2 != nil {
 		return e1.Error() == e2.Error()

--- a/install.go
+++ b/install.go
@@ -12,10 +12,6 @@ func Install(pkg *Package, t PkgTarget) PkgTarget {
 	if pkg.SkipInstall {
 		return t
 	}
-	if pkg.isMain() {
-		Debugf("%v is a main package, not installing", pkg)
-		return t
-	}
 	if pkg.Scope == "test" {
 		Debugf("%v is test scoped, not installing", pkg)
 		return t
@@ -28,27 +24,20 @@ func Install(pkg *Package, t PkgTarget) PkgTarget {
 	return &i
 }
 
-// cachePackage returns a PkgTarget representing the cached output of
-// pkg.
-func cachedPackage(pkg *Package) *cachedPkgTarget {
-	return &cachedPkgTarget{
-		pkg: pkg,
-	}
-}
-
-type cachedPkgTarget struct {
+// cachePackage returns a PkgTarget representing the cached output of pkg.
+type cachedPackage struct {
 	pkg *Package
 }
 
-func (c *cachedPkgTarget) Pkgfile() string {
+func (c *cachedPackage) Pkgfile() string {
 	return pkgfile(c.pkg)
 }
 
-func (c *cachedPkgTarget) String() string {
+func (c *cachedPackage) String() string {
 	return fmt.Sprintf("cached %v", c.pkg.ImportPath)
 }
 
-func (c *cachedPkgTarget) Result() error {
+func (c *cachedPackage) Result() error {
 	// TODO(dfc) _, err := os.Stat(c.Pkgfile())
 	return nil
 }

--- a/install.go
+++ b/install.go
@@ -42,6 +42,18 @@ func (c *cachedPackage) Result() error {
 	return nil
 }
 
+type cachedTarget struct {
+	target Target
+}
+
+func (c *cachedTarget) String() string {
+	return fmt.Sprintf("cached %v", c.target)
+}
+
+func (c *cachedTarget) Result() error {
+	return nil
+}
+
 type install struct {
 	target
 	PkgTarget
@@ -120,6 +132,9 @@ func isStale(pkg *Package) bool {
 	}
 
 	srcs := stringList(pkg.GoFiles, pkg.CFiles, pkg.CXXFiles, pkg.MFiles, pkg.HFiles, pkg.SFiles, pkg.CgoFiles, pkg.SysoFiles, pkg.SwigFiles, pkg.SwigCXXFiles)
+
+	// TODO(dfc) is pkg.isMain(), check to see if the binfile is up to date
+
 	for _, src := range srcs {
 		if olderThan(filepath.Join(pkg.Dir, src)) {
 			return true

--- a/install_test.go
+++ b/install_test.go
@@ -25,7 +25,7 @@ func TestStale(t *testing.T) {
 		pkgs: []string{"a", "b"},
 		stale: map[string]bool{
 			"a": false,
-			"b": true,
+			"b": false,
 		},
 	}}
 

--- a/install_test.go
+++ b/install_test.go
@@ -54,6 +54,8 @@ func TestStale(t *testing.T) {
 		return p
 	}
 
+	Verbose = true
+	defer func() { Verbose = false }()
 	for _, tt := range tests {
 		ctx := newctx()
 		defer ctx.Destroy()


### PR DESCRIPTION
Fixes #294 

This PR allows gb to consider main packages cacheable. Additionally the linking step is only performed if the main package is stale. The net result is running `gb build all` a second time should compile nothing.

TODO:
- [x] if binary is removed from $PROJECT/bin, it will not be replaced til the code is considered stale. 