### PR TITLE
cgo pkg-config fixes

### DIFF
--- a/cgo.go
+++ b/cgo.go
@@ -18,8 +18,7 @@ func (t cgoTarget) Objfile() string { return string(t) }
 func (t cgoTarget) Result() error   { return nil }
 
 // rungcc1 invokes gcc to compile cfile into ofile
-func rungcc1(pkg *Package, ofile, cfile string) Target {
-	_, cgoCFLAGS, _, _ := cflags(pkg, true)
+func rungcc1(pkg *Package, cgoCFLAGS []string, ofile, cfile string) Target {
 	args := []string{"-fPIC", "-m64", "-pthread", "-fmessage-length=0",
 		"-I", pkg.Dir,
 		"-I", filepath.Dir(ofile),

--- a/cgo14.go
+++ b/cgo14.go
@@ -24,7 +24,7 @@ func cgo(pkg *Package) ([]ObjTarget, []string) {
 	cgoCFLAGS = append(cgoCFLAGS, pcCFLAGS...)
 	cgoLDFLAGS = append(cgoLDFLAGS, pcLDFLAGS...)
 
-	if err := runcgo1(pkg, cgoCFLAGS, cgoLDFLAGS); err != nil {
+	if err := runcgo1(pkg, cgoCFLAGS, pcCFLAGS, cgoLDFLAGS); err != nil {
 		return fn(ErrTarget{err})
 	}
 
@@ -79,7 +79,7 @@ func cgo(pkg *Package) ([]ObjTarget, []string) {
 }
 
 // runcgo1 invokes the cgo tool to process pkg.CgoFiles.
-func runcgo1(pkg *Package, cflags, ldflags []string) error {
+func runcgo1(pkg *Package, cflags, pcflags, ldflags []string) error {
 	cgo := cgotool(pkg.Context)
 	objdir := pkg.Objdir()
 	if err := mkdir(objdir); err != nil {
@@ -91,6 +91,7 @@ func runcgo1(pkg *Package, cflags, ldflags []string) error {
 		"--",
 		"-I", pkg.Dir,
 	}
+	args = append(args, pcflags...)
 	args = append(args, pkg.CgoFiles...)
 
 	cgoenv := []string{

--- a/cgo14.go
+++ b/cgo14.go
@@ -51,7 +51,7 @@ func cgo(pkg *Package) ([]ObjTarget, []string) {
 	for _, cfile := range cfiles {
 		ofile := filepath.Join(pkg.Objdir(), stripext(filepath.Base(cfile))+".o")
 		ofiles = append(ofiles, ofile)
-		if err := rungcc1(pkg, ofile, cfile).Result(); err != nil {
+		if err := rungcc1(pkg, cgoCFLAGS, ofile, cfile).Result(); err != nil {
 			return fn(ErrTarget{err})
 		}
 	}

--- a/cgo15.go
+++ b/cgo15.go
@@ -46,7 +46,7 @@ func cgo(pkg *Package) ([]ObjTarget, []string) {
 	for _, cfile := range cfiles {
 		ofile := filepath.Join(pkg.Objdir(), stripext(filepath.Base(cfile))+".o")
 		ofiles = append(ofiles, ofile)
-		targets = append(targets, rungcc1(pkg, ofile, cfile))
+		targets = append(targets, rungcc1(pkg, cgoCFLAGS, ofile, cfile))
 	}
 
 	for _, t := range targets {


### PR DESCRIPTION
This fixes two issues with cgo support:

 * In go 1.4, the pkg-config values must be passed to cgo after the -- (might be the same for go 1.5). CGO_CFLAGS seems to be ignored.
 * Both versions require the cflags/pkg-config to be passed to rungcc1.

Repo which replicates this issue with working output vs current gb master output: https://github.com/sheenobu/gb-cgo-bug