### PR TITLE
fix (gb plugin): avoid panic when no argument is provided

### DIFF
--- a/cmd/gb/plugin.go
+++ b/cmd/gb/plugin.go
@@ -58,6 +58,9 @@ See gb help plugins.
 		if args[0] == "plugin" {
 			args = args[1:]
 		}
+		if len(args) == 0 {
+			return nil
+		}
 		return flags.Parse(args[1:])
 	},
 }


### PR DESCRIPTION
Hi,

On a fresh host (go 1.5): 
$ go get github.com/constabulary/gb/...

Before fix:
$ gb plugin
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
main.glob.func5(0xc82011a2a0, 0xc82000a2f0, 0x0, 0x0, 0x0, 0x0)
        /home/proullon/work/src/github.com/constabulary/gb/cmd/gb/plugin.go:61 +0x174
main.main()
        /home/proullon/work/src/github.com/constabulary/gb/cmd/gb/main.go:66 +0x4a8

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1696 +0x1


After fix: 
$ gb plugin
FATAL command "plugin" failed: plugin: unable to locate "gb-plugin": exec: "gb-plugin": executable file not found in $PATH