### PR TITLE
cmd/gb: verify the Go install has not changed

### DIFF
--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"flag"
+	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
@@ -46,6 +49,9 @@ func main() {
 		help(args[2:])
 		return
 	}
+
+	verifyGoVersion()
+
 	command, ok := commands[name]
 	if (command != nil && !command.Runnable()) || !ok {
 		if _, err := lookupPlugin(name); err != nil {
@@ -103,5 +109,21 @@ func main() {
 	gb.Debugf("args: %v", args)
 	if err := command.Run(ctx, args); err != nil {
 		gb.Fatalf("command %q failed: %v", name, err)
+	}
+}
+
+// verify that the version of Go that compiled this binary is still correct.
+func verifyGoVersion() {
+	want := runtime.Version()
+	filename := filepath.Join(runtime.GOROOT(), "VERSION")
+	if strings.Contains(want, "devel") {
+		filename += ".cache"
+	}
+	got, err := ioutil.ReadFile(filename)
+	if err != nil {
+		gb.Fatalf("cannot validate Go version: %v", err)
+	}
+	if want != string(got) {
+		gb.Fatalf("Go version does not match: gb was compiled with %q, installed Go version from %v is %q", want, runtime.GOROOT(), got)
 	}
 }


### PR DESCRIPTION
Update #319 

This PR adds a check to attempt to diagnose gb failures due to a mismatch between the version of Go that compiled gb, and the version of Go that exists on the machine when gb is invoked.

I expect it will cause some false positives, and if so, we'll address them or remove the check.
```
% gb build
FATAL Go version does not match: gb was compiled with "devel +fa87cf8 Wed Aug 19 04:36:55 2015 +0000", installed Go version from /home/dfc/go is "devel +8ca7856 Sat Aug 22 18:39:29 2015 +0000"
```