### PR TITLE
Introduce ctxString

### DIFF
--- a/context.go
+++ b/context.go
@@ -119,7 +119,7 @@ func (c *Context) IncludePaths() []string {
 
 // Pkgdir returns the path to precompiled packages.
 func (c *Context) Pkgdir() string {
-	return filepath.Join(c.Project.Pkgdir(), c.gotargetos, c.gotargetarch)
+	return filepath.Join(c.Project.Pkgdir(), c.ctxString())
 }
 
 // Workdir returns the path to this Context's working directory.
@@ -154,6 +154,16 @@ func (c *Context) ResolvePackageWithTests(path string) (*Package, error) {
 func (c *Context) Destroy() error {
 	Debugf("removing work directory: %v", c.workdir)
 	return os.RemoveAll(c.workdir)
+}
+
+// ctxString returns a string representation of the unique properties
+// of the context.
+func (c *Context) ctxString() string {
+	v := []string{
+		c.gotargetos,
+		c.gotargetarch,
+	}
+	return strings.Join(v, "-")
 }
 
 func run(dir string, env []string, command string, args ...string) error {

--- a/context_test.go
+++ b/context_test.go
@@ -1,6 +1,7 @@
 package gb
 
 import (
+	"runtime"
 	"runtime/debug"
 	"strings"
 	"testing"
@@ -31,4 +32,26 @@ func TestSimpleCycleDetection(t *testing.T) {
 
 func TestLongCycleDetection(t *testing.T) {
 	testImportCycle("cycle2/a", t)
+}
+
+func TestContextCtxString(t *testing.T) {
+	tests := []struct {
+		opts []func(*Context) error
+		want string
+	}{
+		{nil, runtime.GOOS + "-" + runtime.GOARCH},
+	}
+
+	proj := testProject(t)
+	for _, tt := range tests {
+		ctx, err := proj.NewContext(tt.opts...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ctx.Destroy()
+		got := ctx.ctxString()
+		if got != tt.want {
+			t.Errorf("NewContext(%q).ctxString(): got %v, want %v", tt.opts, got, tt.want)
+		}
+	}
 }

--- a/package.go
+++ b/package.go
@@ -96,9 +96,9 @@ func (pkg *Package) Binfile() string {
 		target = filepath.Join(pkg.Bindir(), binname(pkg))
 	}
 
-	// if this is a cross compile, add -$GOOS-$GOARCH
+	// if this is a cross compile, add ctxString
 	if pkg.isCrossCompile() {
-		target += "-" + pkg.gotargetos + "-" + pkg.gotargetarch
+		target += "-" + pkg.ctxString()
 	}
 
 	if pkg.gotargetos == "windows" {


### PR DESCRIPTION
It's a horrible name, I couldn't think of a better one.

ctxString represents a hyphen seperated string of identifying
properties of the Context. GOOS and GOARCH are the key ones, but
others like -tags, -race, -nocgo, etc may be present.

Not supported yet, but if present, additional context elements must
be sorted aphabetically.