### PR TITLE
cmd/gb: finally fix plugin handling

### DIFF
--- a/cmd/gb/plugin.go
+++ b/cmd/gb/plugin.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"flag"
 	"fmt"
-	"os"
 	"os/exec"
 
-	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
 )
 
@@ -15,60 +12,20 @@ func init() {
 }
 
 var PluginCmd = &cmd.Command{
-	Name:      "plugin",
-	UsageLine: `plugin command`,
-	Short:     "run a plugin",
-	Long: `gb supports git style plugins
+	Name:  "plugin",
+	Short: "plugin information",
+	Long: `gb supports git style plugins.
 
-See gb help plugins.
+A gb plugin is anything in the $PATH with the prefix gb-. In other words
+gb-something, becomes gb something.
 
+gb plugins are executed from the parent gb process with the environment
+variable, GB_PROJECT_DIR set to the root of the current project.
+
+gb plugins can be executed directly but this is rarely useful, so authors
+should attempt to diagnose this by looking for the presence of the 
+GB_PROJECT_DIR environment key.
 `,
-	Run: func(ctx *gb.Context, args []string) error {
-		if len(args) < 1 {
-			return fmt.Errorf("plugin: no command supplied")
-		}
-
-		path, err := lookupPlugin(args[0])
-		if err != nil {
-			return err
-		}
-		args[0] = path
-
-		env := cmd.MergeEnv(os.Environ(), map[string]string{
-			"GB_PROJECT_DIR": ctx.Projectdir(),
-		})
-
-		cmd := exec.Cmd{
-			Path: path,
-			Args: args,
-			Env:  env,
-
-			Stdin:  os.Stdin,
-			Stdout: os.Stdout,
-			Stderr: os.Stderr,
-		}
-
-		return cmd.Run()
-	},
-	// plugin should not interpret arguments
-	ParseArgs: func(_ *gb.Context, _ string, args []string) []string { return args },
-
-	FlagParse: func(flags *flag.FlagSet, args []string) error {
-		if len(args) == 0 {
-			return nil
-		}
-		args = args[1:]
-		if len(args) == 0 {
-			return nil
-		}
-		if args[0] == "plugin" {
-			args = args[1:]
-		}
-		if len(args) == 0 {
-			return nil
-		}
-		return flags.Parse(args[1:])
-	},
 }
 
 func lookupPlugin(arg string) (string, error) {


### PR DESCRIPTION
Fixes #318

- Replace plugin with help text, plugin is not a "runnable" command
- Hard wire plugin behavior inside main.go