### PR TITLE
Refactor logging

### DIFF
--- a/build.go
+++ b/build.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/constabulary/gb/log"
 )
 
 // Build builds each of pkgs in succession. If pkg is a command, then the results of build include
@@ -43,14 +45,14 @@ func BuildPackages(pkgs ...*Package) (*Action, error) {
 	build := Action{
 		Name: fmt.Sprintf("build: %s", strings.Join(names(pkgs), ",")),
 		Task: TaskFn(func() error {
-			Debugf("build duration: %v %v", time.Since(t0), pkgs[0].Statistics.String())
+			log.Debugf("build duration: %v %v", time.Since(t0), pkgs[0].Statistics.String())
 			return nil
 		}),
 	}
 
 	for _, pkg := range pkgs {
 		if len(pkg.GoFiles)+len(pkg.CgoFiles) == 0 {
-			Debugf("skipping %v: no go files", pkg.ImportPath)
+			log.Debugf("skipping %v: no go files", pkg.ImportPath)
 			continue
 		}
 		a, err := BuildPackage(targets, pkg)
@@ -234,7 +236,7 @@ func gc(pkg *Package, gofiles []string) error {
 	t0 := time.Now()
 	if pkg.Scope != "test" {
 		// only log compilation message if not in test scope
-		Infof(pkg.ImportPath)
+		log.Infof(pkg.ImportPath)
 	}
 	includes := pkg.IncludePaths()
 	importpath := pkg.ImportPath

--- a/build_test.go
+++ b/build_test.go
@@ -9,11 +9,13 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/constabulary/gb/log"
 )
 
 func TestBuild(t *testing.T) {
-	Verbose = false
-	defer func() { Verbose = false }()
+	log.Verbose = false
+	defer func() { log.Verbose = false }()
 	tests := []struct {
 		pkg string
 		err error
@@ -73,8 +75,8 @@ func TestBuild(t *testing.T) {
 }
 
 func TestBuildPackage(t *testing.T) {
-	Verbose = false
-	defer func() { Verbose = false }()
+	log.Verbose = false
+	defer func() { log.Verbose = false }()
 	tests := []struct {
 		pkg string
 		err error
@@ -126,8 +128,8 @@ func TestBuildPackage(t *testing.T) {
 }
 
 func TestBuildPackages(t *testing.T) {
-	Verbose = false
-	defer func() { Verbose = false }()
+	log.Verbose = false
+	defer func() { log.Verbose = false }()
 	tests := []struct {
 		pkgs    []string
 		actions []string

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/constabulary/gb"
+	"github.com/constabulary/gb/log"
 )
 
 // Command represents a subcommand, or plugin that is executed within
@@ -65,7 +66,7 @@ func RunCommand(fs *flag.FlagSet, cmd *Command, projectroot, goroot string, args
 	}
 	defer ctx.Destroy()
 
-	gb.Debugf("args: %v", args)
+	log.Debugf("args: %v", args)
 	return cmd.Run(ctx, args)
 }
 
@@ -84,7 +85,7 @@ func NewContext(projectroot string, options ...func(*gb.Context) error) (*gb.Con
 		gb.SourceDir(filepath.Join(root, "vendor", "src")),
 	)
 
-	gb.Debugf("project root %q", project.Projectdir())
+	log.Debugf("project root %q", project.Projectdir())
 	return project.NewContext(options...)
 }
 

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -2,16 +2,15 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"strings"
-
-	"github.com/constabulary/gb"
 )
 
 func MustGetwd() string {
 	wd, err := os.Getwd()
 	if err != nil {
-		gb.Fatalf("unable to determine current working directory: %v", err)
+		log.Fatalf("unable to determine current working directory: %v", err)
 	}
 	return wd
 }

--- a/cmd/gb-vendor/fetch.go
+++ b/cmd/gb-vendor/fetch.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
+	"github.com/constabulary/gb/log"
 	"github.com/constabulary/gb/vendor"
 )
 
@@ -189,7 +190,7 @@ func fetch(ctx *gb.Context, path string, recurse bool) error {
 			keys := keys(missing)
 			sort.Strings(keys)
 			pkg := keys[0]
-			gb.Infof("fetching recursive dependency %s", pkg)
+			log.Infof("fetching recursive dependency %s", pkg)
 			if err := fetch(ctx, pkg, false); err != nil {
 				return err
 			}

--- a/cmd/gb-vendor/main.go
+++ b/cmd/gb-vendor/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
+	"github.com/constabulary/gb/log"
 )
 
 var (
@@ -42,18 +43,18 @@ func main() {
 		help(args[1:])
 		return
 	case projectroot == "":
-		gb.Fatalf("don't run this binary directly, it is meant to be run as 'gb vendor ...'")
+		log.Fatalf("don't run this binary directly, it is meant to be run as 'gb vendor ...'")
 	default:
 	}
 
 	root, err := cmd.FindProjectroot(projectroot)
 	if err != nil {
-		gb.Fatalf("could not locate project root: %v", err)
+		log.Fatalf("could not locate project root: %v", err)
 	}
 	project := gb.NewProject(root,
 		gb.SourceDir(filepath.Join(root, "src")),
 		gb.SourceDir(filepath.Join(root, "vendor", "src")))
-	gb.Debugf("project root %q", project.Projectdir())
+	log.Debugf("project root %q", project.Projectdir())
 
 	for _, command := range commands {
 		if command.Name == args[0] && command.Runnable() {
@@ -69,26 +70,26 @@ func main() {
 				err = fs.Parse(args[1:])
 			}
 			if err != nil {
-				gb.Fatalf("could not parse flags: %v", err)
+				log.Fatalf("could not parse flags: %v", err)
 			}
 			args = fs.Args() // reset args to the leftovers from fs.Parse
-			gb.Debugf("args: %v", args)
+			log.Debugf("args: %v", args)
 
 			ctx, err := project.NewContext(
 				gb.GcToolchain(),
 			)
 			if err != nil {
-				gb.Fatalf("unable to construct context: %v", err)
+				log.Fatalf("unable to construct context: %v", err)
 			}
 			defer ctx.Destroy()
 
 			if err := command.Run(ctx, args); err != nil {
-				gb.Fatalf("command %q failed: %v", command.Name, err)
+				log.Fatalf("command %q failed: %v", command.Name, err)
 			}
 			return
 		}
 	}
-	gb.Fatalf("unknown command %q ", args[0])
+	log.Fatalf("unknown command %q ", args[0])
 }
 
 const manifestfile = "manifest"

--- a/cmd/gb/list.go
+++ b/cmd/gb/list.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"strings"
 	"text/template"
@@ -62,7 +63,7 @@ func list(ctx *gb.Context, args []string) error {
 	}
 	pkgs, err := cmd.ResolvePackages(ctx, args...)
 	if err != nil {
-		gb.Fatalf("unable to resolve: %v", err)
+		log.Fatalf("unable to resolve: %v", err)
 	}
 
 	if jsonOutput {

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
+	"github.com/constabulary/gb/log"
 )
 
 var (
@@ -23,8 +24,8 @@ const (
 )
 
 func init() {
-	fs.BoolVar(&gb.Quiet, "q", gb.Quiet, "suppress log messages below ERROR level")
-	fs.BoolVar(&gb.Verbose, "v", gb.Verbose, "enable log levels below INFO level")
+	fs.BoolVar(&log.Quiet, "q", log.Quiet, "suppress log messages below ERROR level")
+	fs.BoolVar(&log.Verbose, "v", log.Verbose, "enable log levels below INFO level")
 	fs.StringVar(&cwd, "R", cmd.MustGetwd(), "set the project root") // actually the working directory to start the project root search
 
 	fs.Usage = usage
@@ -54,7 +55,7 @@ func main() {
 	if (command != nil && !command.Runnable()) || !ok {
 		plugin, err := lookupPlugin(name)
 		if err != nil {
-			gb.Errorf("unknown command %q", name)
+			log.Errorf("unknown command %q", name)
 			fs.Usage()
 			os.Exit(1)
 		}
@@ -98,7 +99,7 @@ func main() {
 		err = fs.Parse(args[2:])
 	}
 	if err != nil {
-		gb.Fatalf("could not parse flags: %v", err)
+		log.Fatalf("could not parse flags: %v", err)
 	}
 
 	args = fs.Args() // reset args to the leftovers from fs.Parse
@@ -107,7 +108,7 @@ func main() {
 	}
 	cwd, err := filepath.Abs(cwd) // if cwd was passed in via -R, make sure it is absolute
 	if err != nil {
-		gb.Fatalf("could not make project root absolute: %v", err)
+		log.Fatalf("could not make project root absolute: %v", err)
 	}
 
 	ctx, err := cmd.NewContext(
@@ -117,7 +118,7 @@ func main() {
 		gb.Ldflags(ldflags),
 	)
 	if err != nil {
-		gb.Fatalf("unable to construct context: %v", err)
+		log.Fatalf("unable to construct context: %v", err)
 	}
 
 	if !noDestroyContext {
@@ -130,8 +131,8 @@ func main() {
 		args = cmd.ImportPaths(ctx, cwd, args)
 	}
 
-	gb.Debugf("args: %v", args)
+	log.Debugf("args: %v", args)
 	if err := command.Run(ctx, args); err != nil {
-		gb.Fatalf("command %q failed: %v", name, err)
+		log.Fatalf("command %q failed: %v", name, err)
 	}
 }

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -55,7 +55,7 @@ func main() {
 	if (command != nil && !command.Runnable()) || !ok {
 		plugin, err := lookupPlugin(name)
 		if err != nil {
-			log.Errorf("unknown command %q", name)
+			fmt.Fprintf(os.Stderr, "FATAL: unknown command %q\n", name)
 			fs.Usage()
 			os.Exit(1)
 		}

--- a/cmd/gotest.go
+++ b/cmd/gotest.go
@@ -24,6 +24,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/constabulary/gb"
+	"github.com/constabulary/gb/log"
 )
 
 type coverInfo struct {
@@ -91,7 +92,7 @@ func loadTestFuncs(ptest *build.Package) (*testFuncs, error) {
 	t := &testFuncs{
 		Package: ptest,
 	}
-	gb.Debugf("loadTestFuncs: %v, %v", ptest.TestGoFiles, ptest.XTestGoFiles)
+	log.Debugf("loadTestFuncs: %v, %v", ptest.TestGoFiles, ptest.XTestGoFiles)
 	for _, file := range ptest.TestGoFiles {
 		if err := t.load(filepath.Join(ptest.Dir, file), "_test", &t.ImportTest, &t.NeedTest); err != nil {
 			return nil, err

--- a/cmd/path.go
+++ b/cmd/path.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -47,7 +48,7 @@ func relImportPath(root, path string) string {
 		var err error
 		path, err = filepath.Rel(root, path)
 		if err != nil {
-			gb.Fatalf("could not convert relative path %q to absolute: %v", path, err)
+			log.Fatalf("could not convert relative path %q to absolute: %v", path, err)
 		}
 	}
 	return path

--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -5,6 +5,7 @@ import (
 	"go/build"
 
 	"github.com/constabulary/gb"
+	"github.com/constabulary/gb/log"
 )
 
 // Resolver resolves packages.
@@ -48,7 +49,7 @@ func ResolvePackagesWithTests(r Resolver, paths ...string) ([]*gb.Package, error
 		pkg, err := r.ResolvePackageWithTests(path)
 		if err != nil {
 			if _, ok := err.(*build.NoGoError); ok {
-				gb.Debugf("skipping %q", path)
+				log.Debugf("skipping %q", path)
 				continue
 			}
 			return pkgs, fmt.Errorf("failed to resolve package %q: %v", path, err)

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/constabulary/gb"
+	"github.com/constabulary/gb/log"
 )
 
 // Test returns a Target representing the result of compiling the
@@ -45,7 +46,7 @@ func TestPackages(flags []string, pkgs ...*gb.Package) (*gb.Action, error) {
 	test := gb.Action{
 		Name: fmt.Sprintf("test: %s", strings.Join(names(pkgs), ",")),
 		Task: gb.TaskFn(func() error {
-			gb.Debugf("test duration: %v %v", time.Since(t0), pkgs[0].Statistics.String())
+			log.Debugf("test duration: %v %v", time.Since(t0), pkgs[0].Statistics.String())
 			return nil
 		}),
 	}
@@ -167,7 +168,7 @@ func TestPackage(targets map[string]*gb.Action, pkg *gb.Package, flags []string)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	gb.Debugf("scheduling run of %v", cmd.Args)
+	log.Debugf("scheduling run of %v", cmd.Args)
 	return &gb.Action{
 		Name: fmt.Sprintf("run: %s", cmd.Args),
 		Deps: []*gb.Action{testmain},

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -8,11 +8,12 @@ import (
 	"time"
 
 	"github.com/constabulary/gb"
+	"github.com/constabulary/gb/log"
 )
 
 func TestTest(t *testing.T) {
-	gb.Verbose = false
-	defer func() { gb.Verbose = false }()
+	log.Verbose = false
+	defer func() { log.Verbose = false }()
 	tests := []struct {
 		pkg      string
 		testArgs []string

--- a/context.go
+++ b/context.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/constabulary/gb/log"
 )
 
 // Context represents an execution of one or more Targets inside a Project.
@@ -175,7 +177,7 @@ func (c *Context) ResolvePackageWithTests(path string) (*Package, error) {
 
 // Destroy removes the temporary working files of this context.
 func (c *Context) Destroy() error {
-	Debugf("removing work directory: %v", c.workdir)
+	log.Debugf("removing work directory: %v", c.workdir)
 	return os.RemoveAll(c.workdir)
 }
 
@@ -204,7 +206,7 @@ func runOut(output io.Writer, dir string, env []string, command string, args ...
 	cmd.Stdout = output
 	cmd.Stderr = os.Stderr
 	cmd.Env = mergeEnvLists(env, envForDir(cmd.Dir))
-	Debugf("cd %s; %s", cmd.Dir, cmd.Args)
+	log.Debugf("cd %s; %s", cmd.Dir, cmd.Args)
 	err := cmd.Run()
 	return err
 }
@@ -307,7 +309,7 @@ func (c *Context) isCrossCompile() bool {
 }
 
 func matchPackages(c *Context, pattern string) []string {
-	Debugf("matchPackages: %v %v", c.srcdirs[0].Root, pattern)
+	log.Debugf("matchPackages: %v %v", c.srcdirs[0].Root, pattern)
 	match := func(string) bool { return true }
 	treeCanMatch := func(string) bool { return true }
 	if pattern != "all" && pattern != "std" {

--- a/gb.go
+++ b/gb.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/constabulary/gb/log"
 )
 
 // Toolchain represents a standardised set of command line tools
@@ -80,7 +82,7 @@ func (fn TaskFn) Run() error { return fn() }
 func mktmpdir() string {
 	d, err := ioutil.TempDir("", "gb")
 	if err != nil {
-		Fatalf("could not create temporary directory: %v", err)
+		log.Fatalf("could not create temporary directory: %v", err)
 	}
 	return d
 }
@@ -104,7 +106,7 @@ func copyfile(dst, src string) error {
 		return fmt.Errorf("copyfile: create(%q): %v", dst, err)
 	}
 	defer w.Close()
-	Debugf("copyfile(dst: %v, src: %v)", dst, src)
+	log.Debugf("copyfile(dst: %v, src: %v)", dst, src)
 	_, err = io.Copy(w, r)
 	return err
 }

--- a/gc.go
+++ b/gc.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+
+	"github.com/constabulary/gb/log"
 )
 
 // gc toolchain
@@ -120,7 +122,7 @@ func (t *gcToolchain) compiler() string { return t.gc }
 func (t *gcToolchain) linker() string   { return t.ld }
 
 func (t *gcToolchain) Gc(pkg *Package, searchpaths []string, importpath, srcdir, outfile string, files []string) error {
-	Debugf("gc:gc %v %v %v %v", importpath, srcdir, outfile, files)
+	log.Debugf("gc:gc %v %v %v %v", importpath, srcdir, outfile, files)
 	args := append(pkg.gcflags, "-p", importpath, "-pack")
 	args = append(args, "-o", outfile)
 	for _, d := range searchpaths {

--- a/log/log.go
+++ b/log/log.go
@@ -1,4 +1,4 @@
-package gb
+package log
 
 import (
 	"fmt"

--- a/log/log.go
+++ b/log/log.go
@@ -18,10 +18,6 @@ func Fatalf(format string, args ...interface{}) {
 	os.Exit(1)
 }
 
-func Errorf(format string, args ...interface{}) {
-	fmt.Printf("ERROR "+format+"\n", args...)
-}
-
 func Warnf(format string, args ...interface{}) {
 	fmt.Printf("WARNING "+format+"\n", args...)
 }

--- a/log/log.go
+++ b/log/log.go
@@ -18,10 +18,6 @@ func Fatalf(format string, args ...interface{}) {
 	os.Exit(1)
 }
 
-func Warnf(format string, args ...interface{}) {
-	fmt.Printf("WARNING "+format+"\n", args...)
-}
-
 func Infof(format string, args ...interface{}) {
 	if !Quiet {
 		if Verbose {

--- a/vendor/imports.go
+++ b/vendor/imports.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/constabulary/gb"
+	"github.com/constabulary/gb/log"
 )
 
 // ParseImports parses Go packages from a specific root returning a set of import paths.
@@ -76,7 +76,7 @@ func fetchMetadata(scheme, path string, insecure bool) (io.ReadCloser, error) {
 		}
 	case "http":
 		if !insecure {
-			gb.Infof("skipping insecure protocol: %v", url)
+			log.Infof("skipping insecure protocol: %v", url)
 		} else {
 			resp, err = http.Get(url)
 			if err == nil {

--- a/vendor/repo.go
+++ b/vendor/repo.go
@@ -12,7 +12,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/constabulary/gb"
+	"github.com/constabulary/gb/log"
 )
 
 // RemoteRepo describes a remote dvcs repository.
@@ -248,7 +248,7 @@ func probe(vcs func(*url.URL) error, url *url.URL, insecure bool, schemes ...str
 			}
 		case "http", "git":
 			if !insecure {
-				gb.Infof("skipping insecure protocol: %s", url.String())
+				log.Infof("skipping insecure protocol: %s", url.String())
 				continue
 			}
 			if err := vcs(&url); err == nil {


### PR DESCRIPTION
Refactor logging

- move log functions into their own package, `log`. Hopefully one day in the future this can be outsourced. 
- Logging is now more opinionated, there are only three levels and three corresponding log commands, `Debugf`, `Infof` and `Fataf`. `Verbose` enables debug level, `Quiet` silences info level, that's all there is too it. Errors, if not fatal should be handled and printed at info level -- they were not fatal after all.