### PR TITLE
cmd/gb: gb info report pkg path and bin suffix

### DIFF
--- a/cmd/gb/info.go
+++ b/cmd/gb/info.go
@@ -25,6 +25,8 @@ info returns 0 if the project is well formed, and non zero otherwise.
 func info(ctx *gb.Context, args []string) error {
 	fmt.Printf("GB_PROJECT_DIR=%q\n", ctx.Projectdir())
 	fmt.Printf("GB_SRC_PATH=%q\n", joinlist(ctx.Srcdirs()...))
+	fmt.Printf("GB_PKG_DIR=%q\n", ctx.Pkgdir())
+	fmt.Printf("GB_BIN_SUFFIX=%q\n", ctx.Suffix())
 	return nil
 }
 

--- a/context.go
+++ b/context.go
@@ -150,6 +150,16 @@ func (c *Context) Pkgdir() string {
 	return filepath.Join(c.Project.Pkgdir(), c.ctxString())
 }
 
+// Suffix returns the suffix (if any) for binaries produced
+// by this context.
+func (c *Context) Suffix() string {
+	suffix := c.ctxString()
+	if suffix != "" {
+		suffix = "-"+suffix
+	}
+	return suffix
+}
+
 // Workdir returns the path to this Context's working directory.
 func (c *Context) Workdir() string { return c.workdir }
 


### PR DESCRIPTION
Fixes #366

```
% gb info
GB_PROJECT_DIR="/Users/dfc"
GB_SRC_PATH="/Users/dfc/src:/Users/dfc/vendor/src"
GB_PKG_DIR="/Users/dfc/pkg/darwin-amd64"
GB_BIN_SUFFIX="-darwin-amd64"
```