### PR TITLE
Fix: Clean working directory

### DIFF
--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -133,6 +133,9 @@ func main() {
 
 	log.Debugf("args: %v", args)
 	if err := command.Run(ctx, args); err != nil {
+		if !noDestroyContext {
+			ctx.Destroy()
+		}
 		log.Fatalf("command %q failed: %v", name, err)
 	}
 }


### PR DESCRIPTION
`gb test` failed leak working directory.
`log.Fatal` call `os.Eixt`. deferred functions are not run.
