### PR TITLE
cgo: use unique directory for build

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -171,6 +171,31 @@ func TestBuildPackages(t *testing.T) {
 	}
 }
 
+func TestObjfile(t *testing.T) {
+	var tests = []struct {
+		pkg  string // package name
+		want string // objfile result
+	}{
+		{pkg: "b", want: "b/main.a"},
+		{pkg: "nested/a", want: "nested/a.a"},
+		{pkg: "nested/b", want: "nested/b.a"},
+	}
+
+	for _, tt := range tests {
+		ctx := testContext(t)
+		defer ctx.Destroy()
+		pkg, err := ctx.ResolvePackage(tt.pkg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := objfile(pkg)
+		want := filepath.Join(ctx.Workdir(), tt.want)
+		if want != got {
+			t.Errorf("(%s).Objdir(): want %s, got %s", tt.pkg, want, got)
+		}
+	}
+}
+
 func TestPkgname(t *testing.T) {
 	tests := []struct {
 		pkg  string
@@ -193,6 +218,31 @@ func TestPkgname(t *testing.T) {
 		}
 		if got, want := pkgname(pkg), tt.name; got != want {
 			t.Errorf("pkgname(%v): want %v, got %v", want, got)
+		}
+	}
+}
+
+func TestCgoobjdir(t *testing.T) {
+	var tests = []struct {
+		pkg  string // package name
+		want string // objdir result
+	}{
+		{pkg: "b", want: "main/_cgo"},
+		{pkg: "nested/a", want: "nested/a/_cgo"},
+		{pkg: "nested/b", want: "nested/b/_cgo"},
+	}
+
+	for _, tt := range tests {
+		ctx := testContext(t)
+		defer ctx.Destroy()
+		pkg, err := ctx.ResolvePackage(tt.pkg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := cgoobjdir(pkg)
+		want := filepath.Join(ctx.Workdir(), tt.want)
+		if want != got {
+			t.Errorf("(%s).cgoobjdir(): want %s, got %s", tt.pkg, want, got)
 		}
 	}
 }

--- a/cgo.go
+++ b/cgo.go
@@ -54,18 +54,18 @@ func cgo14(pkg *Package) (*Action, []string, []string, error) {
 		}),
 	}
 
-	cgofiles := []string{filepath.Join(pkg.Objdir(), "_cgo_gotypes.go")}
+	cgofiles := []string{filepath.Join(cgoobjdir(pkg), "_cgo_gotypes.go")}
 	for _, f := range pkg.CgoFiles {
-		cgofiles = append(cgofiles, filepath.Join(pkg.Objdir(), stripext(f)+".cgo1.go"))
+		cgofiles = append(cgofiles, filepath.Join(cgoobjdir(pkg), stripext(f)+".cgo1.go"))
 	}
 	cfiles := []string{
-		filepath.Join(pkg.Objdir(), "_cgo_main.c"),
-		filepath.Join(pkg.Objdir(), "_cgo_export.c"),
+		filepath.Join(cgoobjdir(pkg), "_cgo_main.c"),
+		filepath.Join(cgoobjdir(pkg), "_cgo_export.c"),
 	}
 	cfiles = append(cfiles, pkg.CFiles...)
 
 	for _, f := range pkg.CgoFiles {
-		cfiles = append(cfiles, filepath.Join(pkg.Objdir(), stripext(f)+".cgo2.c"))
+		cfiles = append(cfiles, filepath.Join(cgoobjdir(pkg), stripext(f)+".cgo2.c"))
 	}
 
 	cflags := append(cgoCPPFLAGS, cgoCFLAGS...)
@@ -80,7 +80,7 @@ func cgo14(pkg *Package) (*Action, []string, []string, error) {
 		}),
 	}
 
-	dynout := filepath.Join(pkg.Objdir(), "_cgo_import.c")
+	dynout := filepath.Join(cgoobjdir(pkg), "_cgo_import.c")
 	imports := stripext(dynout) + ".o"
 	runcgo2 := Action{
 		Name: "runcgo2: " + pkg.ImportPath,
@@ -128,18 +128,18 @@ func cgo15(pkg *Package) (*Action, []string, []string, error) {
 		},
 	}
 
-	cgofiles := []string{filepath.Join(pkg.Objdir(), "_cgo_gotypes.go")}
+	cgofiles := []string{filepath.Join(cgoobjdir(pkg), "_cgo_gotypes.go")}
 	for _, f := range pkg.CgoFiles {
-		cgofiles = append(cgofiles, filepath.Join(pkg.Objdir(), stripext(f)+".cgo1.go"))
+		cgofiles = append(cgofiles, filepath.Join(cgoobjdir(pkg), stripext(f)+".cgo1.go"))
 	}
 	cfiles := []string{
-		filepath.Join(pkg.Objdir(), "_cgo_main.c"),
-		filepath.Join(pkg.Objdir(), "_cgo_export.c"),
+		filepath.Join(cgoobjdir(pkg), "_cgo_main.c"),
+		filepath.Join(cgoobjdir(pkg), "_cgo_export.c"),
 	}
 	cfiles = append(cfiles, pkg.CFiles...)
 
 	for _, f := range pkg.CgoFiles {
-		cfiles = append(cfiles, filepath.Join(pkg.Objdir(), stripext(f)+".cgo2.c"))
+		cfiles = append(cfiles, filepath.Join(cgoobjdir(pkg), stripext(f)+".cgo2.c"))
 	}
 
 	cflags := append(cgoCPPFLAGS, cgoCFLAGS...)
@@ -154,7 +154,7 @@ func cgo15(pkg *Package) (*Action, []string, []string, error) {
 		}),
 	}
 
-	dynout := filepath.Join(pkg.Objdir(), "_cgo_import.go")
+	dynout := filepath.Join(cgoobjdir(pkg), "_cgo_import.go")
 	runcgo2 := Action{
 		Name: "runcgo2: " + pkg.ImportPath,
 		Deps: []*Action{&gcc2},
@@ -183,7 +183,7 @@ func cgocc(pkg *Package, cflags, cxxflags, cfiles, cxxfiles []string, deps ...*A
 	var ofiles []string
 	for _, cfile := range cfiles {
 		cfile := cfile
-		ofile := filepath.Join(pkg.Objdir(), stripext(filepath.Base(cfile))+".o")
+		ofile := filepath.Join(cgoobjdir(pkg), stripext(filepath.Base(cfile))+".o")
 		ofiles = append(ofiles, ofile)
 		cc = append(cc, &Action{
 			Name: "rungcc1: " + pkg.ImportPath + ": " + cfile,
@@ -196,7 +196,7 @@ func cgocc(pkg *Package, cflags, cxxflags, cfiles, cxxfiles []string, deps ...*A
 
 	for _, cxxfile := range cxxfiles {
 		cxxfile := cxxfile
-		ofile := filepath.Join(pkg.Objdir(), stripext(filepath.Base(cxxfile))+".o")
+		ofile := filepath.Join(cgoobjdir(pkg), stripext(filepath.Base(cxxfile))+".o")
 		ofiles = append(ofiles, ofile)
 		cc = append(cc, &Action{
 			Name: "rung++1: " + pkg.ImportPath + ": " + cxxfile,
@@ -387,7 +387,7 @@ func quoteFlags(flags []string) []string {
 // runcgo1 invokes the cgo tool to process pkg.CgoFiles.
 func runcgo1(pkg *Package, cflags, ldflags []string) error {
 	cgo := cgotool(pkg.Context)
-	objdir := pkg.Objdir()
+	objdir := cgoobjdir(pkg)
 	if err := mkdir(objdir); err != nil {
 		return err
 	}
@@ -422,7 +422,7 @@ func runcgo1(pkg *Package, cflags, ldflags []string) error {
 // runcgo2 invokes the cgo tool to create _cgo_import.go
 func runcgo2(pkg *Package, dynout, ofile string) error {
 	cgo := cgotool(pkg.Context)
-	objdir := pkg.Objdir()
+	objdir := cgoobjdir(pkg)
 
 	args := []string{
 		"-objdir", objdir,
@@ -443,4 +443,8 @@ func runcgo2(pkg *Package, dynout, ofile string) error {
 		return fmt.Errorf("unsuppored Go version: %v", runtime.Version)
 	}
 	return run(pkg.Dir, nil, cgo, args...)
+}
+
+func cgoobjdir(pkg *Package) string {
+	return filepath.Join(pkg.Objdir(), pkg.Name, "_cgo")
 }

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -133,6 +133,9 @@ func main() {
 
 	log.Debugf("args: %v", args)
 	if err := command.Run(ctx, args); err != nil {
+		if !noDestroyContext {
+			ctx.Destroy()
+		}
 		log.Fatalf("command %q failed: %v", name, err)
 	}
 }

--- a/context.go
+++ b/context.go
@@ -155,7 +155,7 @@ func (c *Context) Pkgdir() string {
 func (c *Context) Suffix() string {
 	suffix := c.ctxString()
 	if suffix != "" {
-		suffix = "-"+suffix
+		suffix = "-" + suffix
 	}
 	return suffix
 }

--- a/gc.go
+++ b/gc.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-
-	"github.com/constabulary/gb/log"
 )
 
 // gc toolchain
@@ -122,7 +120,6 @@ func (t *gcToolchain) compiler() string { return t.gc }
 func (t *gcToolchain) linker() string   { return t.ld }
 
 func (t *gcToolchain) Gc(pkg *Package, searchpaths []string, importpath, srcdir, outfile string, files []string) error {
-	log.Debugf("gc:gc %v %v %v %v", importpath, srcdir, outfile, files)
 	args := append(pkg.gcflags, "-p", importpath, "-pack")
 	args = append(args, "-o", outfile)
 	for _, d := range searchpaths {

--- a/package_test.go
+++ b/package_test.go
@@ -68,3 +68,28 @@ func TestPackageBinfile(t *testing.T) {
 		}
 	}
 }
+
+func TestPackageObjdir(t *testing.T) {
+	var tests = []struct {
+		pkg  string // package name
+		want string // objdir result
+	}{
+		{pkg: "b", want: ""},
+		{pkg: "nested/a", want: "nested"},
+		{pkg: "nested/b", want: "nested"},
+	}
+
+	for _, tt := range tests {
+		ctx := testContext(t)
+		defer ctx.Destroy()
+		pkg, err := ctx.ResolvePackage(tt.pkg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := pkg.Objdir()
+		want := filepath.Join(ctx.Workdir(), tt.want)
+		if want != got {
+			t.Errorf("(%s).Objdir(): want %s, got %s", tt.pkg, want, got)
+		}
+	}
+}

--- a/testdata/src/nested/a/a.go
+++ b/testdata/src/nested/a/a.go
@@ -1,0 +1,3 @@
+package a
+
+const A = `a`

--- a/testdata/src/nested/b/b.go
+++ b/testdata/src/nested/b/b.go
@@ -1,0 +1,3 @@
+package b
+
+const A = `b`


### PR DESCRIPTION
Fixes #372
Updates #331 

Use a unique temporary directory for cgo build files.