### PR TITLE
Avoid passing build flags to test process.

### DIFF
--- a/cmd/testflag.go
+++ b/cmd/testflag.go
@@ -21,6 +21,14 @@ var testFlagDefn = map[string]*testFlagSpec{
 	"cover":     {boolVar: true},
 	"coverpkg":  {},
 	"covermode": {},
+	"a":         {boolVar: true},
+	"r":         {boolVar: true},
+	"f":         {boolVar: true},
+	"F":         {boolVar: true},
+	"P":         {},
+	"ldflags":   {},
+	"gcflags":   {},
+	"dotfile":   {},
 
 	// Passed to the test binary
 	"q":                {boolVar: true, passToTest: true},

--- a/cmd/testflag_test.go
+++ b/cmd/testflag_test.go
@@ -100,6 +100,13 @@ func TestTestFlagsPreParse(t *testing.T) {
 		}, {
 			args:  []string{"-coverpkg", "package"},
 			pargs: []string{"-coverpkg", "package"},
+		}, {
+			args:  []string{"-P", "1"},
+			pargs: []string{"-P", "1"},
+		}, {
+			args:  []string{"-P=1", "-short"},
+			pargs: []string{"-P=1"},
+			eargs: []string{"-short"},
 		}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The gb test command advertises support for all valid
flags to gb build (e.g. -P), but the logic which determines which flags
should be sent to the test binary was not aware of them and blithely
passed them through. Add all valid build flags to the map indicating
they are meant for gb and not to passed through.

Note: It seems like the best long-term solution to this problem would be for the caller to pass through its `flag.FlagSet` and modify `TestFlagsExtraParse` to walk it with `VisitAll`. This would avoid the necessity of update two different locations (in two different packages!) in the code when adding a new flag to `gb test`.