### PR TITLE
Pass workingdir-relative paths to gc to improve error messages

### DIFF
--- a/gc.go
+++ b/gc.go
@@ -3,6 +3,7 @@ package gb
 import (
 	"fmt"
 	"go/build"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -12,6 +13,9 @@ import (
 
 type gcToolchain struct {
 	gc, cc, ld, as, pack string
+
+	run    func(string, []string, string, ...string) error
+	runOut func(io.Writer, string, []string, string, ...string) error
 }
 
 func GcToolchain() func(c *Context) error {
@@ -36,18 +40,22 @@ func GcToolchain() func(c *Context) error {
 				return err
 			}
 			c.tc = &gcToolchain{
-				gc:   filepath.Join(tooldir, archchar+"g"+exe),
-				ld:   filepath.Join(tooldir, archchar+"l"+exe),
-				as:   filepath.Join(tooldir, archchar+"a"+exe),
-				cc:   filepath.Join(tooldir, archchar+"c"+exe),
-				pack: filepath.Join(tooldir, "pack"+exe),
+				gc:     filepath.Join(tooldir, archchar+"g"+exe),
+				ld:     filepath.Join(tooldir, archchar+"l"+exe),
+				as:     filepath.Join(tooldir, archchar+"a"+exe),
+				cc:     filepath.Join(tooldir, archchar+"c"+exe),
+				pack:   filepath.Join(tooldir, "pack"+exe),
+				run:    run,
+				runOut: runOut,
 			}
 		case gc15:
 			c.tc = &gcToolchain{
-				gc:   filepath.Join(tooldir, "compile"+exe),
-				ld:   filepath.Join(tooldir, "link"+exe),
-				as:   filepath.Join(tooldir, "asm"+exe),
-				pack: filepath.Join(tooldir, "pack"+exe),
+				gc:     filepath.Join(tooldir, "compile"+exe),
+				ld:     filepath.Join(tooldir, "link"+exe),
+				as:     filepath.Join(tooldir, "asm"+exe),
+				pack:   filepath.Join(tooldir, "pack"+exe),
+				run:    run,
+				runOut: runOut,
 			}
 		default:
 			return fmt.Errorf("unsupported Go version: %v", runtime.Version)
@@ -73,7 +81,7 @@ func (t *gcToolchain) Asm(pkg *Package, srcdir, ofile, sfile string) error {
 	if err := mkdir(filepath.Dir(ofile)); err != nil {
 		return fmt.Errorf("gc:asm: %v", err)
 	}
-	return run(srcdir, nil, t.as, args...)
+	return t.run(srcdir, nil, t.as, args...)
 }
 
 func (t *gcToolchain) Ld(pkg *Package, searchpaths []string, outfile, afile string) error {
@@ -88,7 +96,7 @@ func (t *gcToolchain) Ld(pkg *Package, searchpaths []string, outfile, afile stri
 	if err := mkdir(filepath.Dir(outfile)); err != nil {
 		return fmt.Errorf("gc:ld: %v", err)
 	}
-	return run(".", nil, t.ld, args...)
+	return t.run(".", nil, t.ld, args...)
 }
 
 func (t *gcToolchain) Cc(pkg *Package, ofile, cfile string) error {
@@ -105,14 +113,14 @@ func (t *gcToolchain) Cc(pkg *Package, ofile, cfile string) error {
 		"-D", "GOARCH_" + pkg.gotargetarch,
 		cfile,
 	}
-	return run(pkg.Dir, nil, t.cc, args...)
+	return t.run(pkg.Dir, nil, t.cc, args...)
 }
 
 func (t *gcToolchain) Pack(pkg *Package, afiles ...string) error {
 	args := []string{"r"}
 	args = append(args, afiles...)
 	dir := filepath.Dir(afiles[0])
-	return run(dir, nil, t.pack, args...)
+	return t.run(dir, nil, t.pack, args...)
 }
 
 func (t *gcToolchain) compiler() string { return t.gc }
@@ -137,9 +145,44 @@ func (t *gcToolchain) Gc(pkg *Package, searchpaths []string, importpath, srcdir,
 		args = append(args, "-asmhdr", asmhdr)
 	}
 
-	args = append(args, files...)
+	relativeFiles, err := relativizePaths(srcdir, files)
+	if err != nil {
+		return err
+	}
+
+	args = append(args, relativeFiles...)
 	if err := mkdir(filepath.Join(filepath.Dir(outfile), pkg.Name)); err != nil {
 		return fmt.Errorf("gc:gc: %v", err)
 	}
-	return runOut(os.Stdout, srcdir, nil, t.gc, args...)
+	return t.runOut(os.Stdout, ".", nil, t.gc, args...)
+}
+
+// relativizePaths takes a base path and set of paths relative to that base path
+// and returns an equivalent slice of paths that are relative to the current
+// working directory
+//
+// e.g.
+// basePath = /x/y
+// paths = q.go z.go
+// cwd = /x
+// returns: [y/q.go, y/z.go]
+func relativizePaths(basePath string, paths []string) ([]string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	relativePaths := make([]string, len(paths))
+	for i, p := range paths {
+		// don't muck with absolute paths
+		if filepath.IsAbs(p) {
+			relativePaths[i] = p
+			continue
+		}
+
+		relativePaths[i], err = filepath.Rel(cwd, filepath.Join(basePath, p))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return relativePaths, nil
 }

--- a/gc_test.go
+++ b/gc_test.go
@@ -1,0 +1,38 @@
+package gb
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestRelativizeGcPaths(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("test needs current working directory to run: %v", err)
+	}
+
+	srcdir := filepath.Join(wd, "x/y")
+	expected := []string{filepath.Join("x", "y", "a.go"), filepath.Join("x", "y", "b.go")}
+	filenames := []string{"a.go", "b.go"}
+
+	var gc gcToolchain
+	gc.runOut = func(_ io.Writer, _ string, env []string, _ string, args ...string) error {
+		// the filenames are the last arguments
+		actual := args[len(args)-len(filenames):]
+		if !reflect.DeepEqual(actual, expected) {
+			t.Errorf("Source file paths were not properly relativized. Actual '%v', Expected: '%v'", actual, expected)
+		}
+		return nil
+	}
+
+	// we just need a fake package structure to pass through to gc.Gc
+	c := testContext(t)
+	p, err := c.ResolvePackage("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gc.Gc(p, []string{}, "", srcdir, "", filenames)
+}


### PR DESCRIPTION
Do not change directory before invoking the gc tool. Instead,
relativize each filepath passed to the gc tool to the current
working directory. This greatly improves error messages produced
by gc since the broken file is now identified by an unambiguous
path.

The testing infrastructure required for this involves introducing
a new runOut variable to gcToolchain so it can be mocked. A similar
run variable is also introduced for parity of implementation and
possible future tests.

Fixes https://github.com/constabulary/gb/issues/341