### PR TITLE
test: do not build a main package called main in test scope

### DIFF
--- a/build.go
+++ b/build.go
@@ -286,12 +286,10 @@ func objfile(pkg *Package) string {
 }
 
 func objname(pkg *Package) string {
-	switch pkg.Name {
-	case "main":
+	if pkg.isMain() {
 		return filepath.Join(filepath.Base(filepath.FromSlash(pkg.ImportPath)), "main.a")
-	default:
-		return filepath.Base(filepath.FromSlash(pkg.ImportPath)) + ".a"
 	}
+	return filepath.Base(filepath.FromSlash(pkg.ImportPath)) + ".a"
 }
 
 func pkgname(pkg *Package) string {
@@ -303,10 +301,10 @@ func pkgname(pkg *Package) string {
 
 func binname(pkg *Package) string {
 	switch {
-	case pkg.Name == "main":
-		return filepath.Base(filepath.FromSlash(pkg.ImportPath))
 	case pkg.Scope == "test":
 		return pkg.Name
+	case pkg.Name == "main":
+		return filepath.Base(filepath.FromSlash(pkg.ImportPath))
 	default:
 		panic("binname called with non main package: " + pkg.ImportPath)
 	}

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestTest(t *testing.T) {
-	log.Verbose = false
+	log.Verbose = true
 	defer func() { log.Verbose = false }()
 	tests := []struct {
 		pkg      string
@@ -64,6 +64,8 @@ func TestTest(t *testing.T) {
 		}, {
 			pkg:      "testflags",
 			testArgs: []string{"-debug"},
+		}, {
+			pkg: "main", // issue 375, a package called main
 		}}
 
 	for _, tt := range tests {

--- a/package.go
+++ b/package.go
@@ -28,9 +28,15 @@ func NewPackage(ctx *Context, p *build.Package) *Package {
 	return &pkg
 }
 
-// isMain returns true if this is a command, a main package.
+// isMain returns true if this is a command, not being built in test scope, and
+// not the testmain itself.
 func (p *Package) isMain() bool {
-	return p.Name == "main" || strings.HasSuffix(p.ImportPath, "testmain") && p.Scope == "test"
+	switch p.Scope {
+	case "test":
+		return strings.HasSuffix(p.ImportPath, "testmain")
+	default:
+		return p.Name == "main"
+	}
 }
 
 // Imports returns the Pacakges that this Package depends on.

--- a/package_test.go
+++ b/package_test.go
@@ -1,6 +1,7 @@
 package gb
 
 import (
+	"go/build"
 	"path/filepath"
 	"testing"
 )
@@ -90,6 +91,88 @@ func TestPackageObjdir(t *testing.T) {
 		want := filepath.Join(ctx.Workdir(), tt.want)
 		if want != got {
 			t.Errorf("(%s).Objdir(): want %s, got %s", tt.pkg, want, got)
+		}
+	}
+}
+
+func TestPackageIsMain(t *testing.T) {
+	var tests = []struct {
+		pkg  *Package
+		want bool
+	}{{
+		pkg: &Package{
+			Package: &build.Package{
+				Name:       "main",
+				ImportPath: "main",
+			},
+		},
+		want: true,
+	}, {
+		pkg: &Package{
+			Package: &build.Package{
+				Name:       "a",
+				ImportPath: "main",
+			},
+		},
+		want: false,
+	}, {
+		pkg: &Package{
+			Package: &build.Package{
+				Name:       "main",
+				ImportPath: "a",
+			},
+		},
+		want: true,
+	}, {
+		pkg: &Package{
+			Package: &build.Package{
+				Name:       "main",
+				ImportPath: "testmain",
+			},
+		},
+		want: true,
+	}, {
+		pkg: &Package{
+			Package: &build.Package{
+				Name:       "main",
+				ImportPath: "main",
+			},
+			Scope: "test",
+		},
+		want: false,
+	}, {
+		pkg: &Package{
+			Package: &build.Package{
+				Name:       "a",
+				ImportPath: "main",
+			},
+			Scope: "test",
+		},
+		want: false,
+	}, {
+		pkg: &Package{
+			Package: &build.Package{
+				Name:       "main",
+				ImportPath: "a",
+			},
+			Scope: "test",
+		},
+		want: false,
+	}, {
+		pkg: &Package{
+			Package: &build.Package{
+				Name:       "main",
+				ImportPath: "testmain",
+			},
+			Scope: "test",
+		},
+		want: true,
+	}}
+
+	for _, tt := range tests {
+		got := tt.pkg.isMain()
+		if got != tt.want {
+			t.Errorf("Package{Name:%q, ImportPath: %q, Scope:%q}.isMain(): got %v, want %v", tt.pkg.Name, tt.pkg.ImportPath, tt.pkg.Scope, got, tt.want)
 		}
 	}
 }

--- a/testdata/src/main/main.go
+++ b/testdata/src/main/main.go
@@ -1,0 +1,1 @@
+package main


### PR DESCRIPTION
Fixes #375

The test for Package.isMain had a loophole where a main package,
being built as a test would be linked.

- [x] Add unit test for Package.isMain