### PR TITLE
Pin wercker to go 1.4.2 (box v1.3.3)

### DIFF
--- a/cgo.go
+++ b/cgo.go
@@ -50,7 +50,7 @@ func cgo14(pkg *Package) (*Action, []string, []string, error) {
 		Name: "cc: " + pkg.ImportPath + ": _cgo_defun_c",
 		Deps: runcgo1,
 		Task: TaskFn(func() error {
-			return pkg.tc.Cc(pkg, defun, filepath.Join(pkg.Objdir(), "_cgo_defun.c"))
+			return pkg.tc.Cc(pkg, defun, filepath.Join(cgoobjdir(pkg), "_cgo_defun.c"))
 		}),
 	}
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: wercker/golang
+box: wercker/golang@1.3.3
 build:
   steps:
     # Sets the go workspace and places you package


### PR DESCRIPTION
The Go 1.4 build atrophied when wercker upgraded to Go 1.5. 

- [x] Pin to Go 1.4.2 
- [x] fix cgo14 error
