### PR TITLE
cmd/gb: add build tags

### DIFF
--- a/cmd/gb/alldocs.go
+++ b/cmd/gb/alldocs.go
@@ -34,16 +34,19 @@ Usage:
 
         gb build [build flags] [packages]
 
-Build compiles the packages named by the import paths, along with their dependencies.
+Build compiles the packages named by the import paths, along with their
+dependencies.
 
-The build flags are
+Flags:
 
 	-f
-		ignore cached packages if present, new packages built will overwrite any cached packages.
-		This effectively disables incremental compilation.
+		ignore cached packages if present, new packages built will overwrite
+		any cached packages. This effectively disables incremental
+		compilation.
 	-F
-		do not cache packages, cached packages will still be used for incremental compilation.
-		-f -F is advised to disable the package caching system.
+		do not cache packages, cached packages will still be used for
+		incremental compilation. -f -F is advised to disable the package
+		caching system.
 	-q
 		decreases verbosity, effectively raising the output level to ERROR.
 		In a successful build, no output will be displayed.
@@ -51,12 +54,15 @@ The build flags are
 		The number of build jobs to run in parallel, including test execution.
 		By default this is the number of CPUs visible to gb.
 	-R
-		sets the base of the project root search path from the current working directory to the value supplied.
-		Effectively gb changes working directory to this path before searching for the project root.
+		sets the base of the project root search path from the current working
+		directory to the value supplied. Effectively gb changes working
+		directory to this path before searching for the project root.
 	-v
-		increases verbosity, effectively lowering the output level from INFO to DEBUG.
+		increases verbosity, effectively lowering the output level from INFO
+		to DEBUG.
 	-dotfile
-		if provided, gb will output a dot formatted file of the build steps to be performed.
+		if provided, gb will output a dot formatted file of the build steps to
+		be performed.
 	-ldflags 'flag list'
 		arguments to pass on each linker invocation.
 	-gcflags 'arg list'
@@ -64,9 +70,11 @@ The build flags are
 	-tags 'tag list'
 		additional build tags.
 
-The list flags accept a space-separated list of strings. To embed spaces in an element in the list, surround it with either single or double quotes.
+The list flags accept a space-separated list of strings. To embed spaces in an
+element in the list, surround it with either single or double quotes.
 
-For more about specifying packages, see 'gb help packages'. For more about where packages and binaries are installed, run 'gb help project'.
+For more about specifying packages, see 'gb help packages'. For more about
+where packages and binaries are installed, run 'gb help project'.
 
 
 Show documentation for a package or symbol
@@ -75,7 +83,9 @@ Usage:
 
         gb doc <pkg> <sym>[.<method>]
 
+Doc shows documentation for a package or symbol.
 
+See 'go help doc'.
 
 
 Print project environment variables
@@ -91,13 +101,14 @@ Generate Go files by processing source
 
 Usage:
 
-        gb generate
+        gb generate [-run regexp] [file.go... | packages]
 
 Generate runs commands described by directives within existing files.
-Those commands can run any process but the intent is to create or update Go
+
+Those commands can run any process, but the intent is to create or update Go
 source files, for instance by running yacc.
 
-See 'go help generate'
+See 'go help generate'.
 
 
 Info returns information about this project
@@ -117,9 +128,9 @@ Usage:
 
         gb list [-s] [-f format] [-json] [packages]
 
-list lists packages.
+List lists packages imported by the project.
 
-The default output shows the package import path:
+The default output shows the package import paths:
 
 	% gb list github.com/constabulary/...
 	github.com/constabulary/gb
@@ -133,8 +144,13 @@ Flags:
 		alternate format for the list, using the syntax of package template.
 		The default output is equivalent to -f '{{.ImportPath}}'. The struct
 		being passed to the template is currently an instance of gb.Package.
-		This structure is under active development and it'As contents are not
-		guarenteed to be stable.
+		This structure is under active development and it's contents are not
+		guaranteed to be stable.
+	-s
+		read format template from STDIN.
+	-json
+		prints output in structured JSON format. WARNING: gb.Package
+		structure is not stable and will change in the future!
 
 
 Plugin information
@@ -168,12 +184,12 @@ Usage:
 
         gb test [build flags] [packages] [flags for test binary]
 
-'gb test' automates testing the packages named by the import paths.
+Test automates testing the packages named by the import paths.
 
 'gb test' recompiles each package along with any files with names matching
 the file pattern "*_test.go".
 
-See 'go help test'
+See 'go help test'.
 
 
 */

--- a/cmd/gb/build.go
+++ b/cmd/gb/build.go
@@ -35,6 +35,8 @@ var (
 	P int // number of executors to run in parallel
 
 	dotfile string // path to dot output file
+
+	buildtags []string
 )
 
 func addBuildFlags(fs *flag.FlagSet) {
@@ -47,6 +49,7 @@ func addBuildFlags(fs *flag.FlagSet) {
 	fs.Var((*stringsFlag)(&ldflags), "ldflags", "flags passed to the linker")
 	fs.Var((*stringsFlag)(&gcflags), "gcflags", "flags passed to the compiler")
 	fs.StringVar(&dotfile, "dotfile", "", "path to dot output file")
+	fs.Var((*stringsFlag)(&buildtags), "tags", "")
 }
 
 var BuildCmd = &cmd.Command{
@@ -86,7 +89,9 @@ Flags:
 	-ldflags 'flag list'
 		arguments to pass on each linker invocation.
 	-gcflags 'arg list'
-		arguments to pass on each go tool compile invocation.
+		arguments to pass on each compile invocation.
+	-tags 'tag list'
+		additional build tags.
 
 The list flags accept a space-separated list of strings. To embed spaces in an
 element in the list, surround it with either single or double quotes.

--- a/cmd/gb/info.go
+++ b/cmd/gb/info.go
@@ -18,7 +18,8 @@ func init() {
 
 info returns 0 if the project is well formed, and non zero otherwise.
 `,
-		Run: info,
+		Run:      info,
+		AddFlags: addBuildFlags,
 	})
 }
 

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -116,6 +116,7 @@ func main() {
 		gb.GcToolchain(),
 		gb.Gcflags(gcflags...),
 		gb.Ldflags(ldflags...),
+		gb.Tags(buildtags...),
 	)
 	if err != nil {
 		log.Fatalf("unable to construct context: %v", err)

--- a/context.go
+++ b/context.go
@@ -39,6 +39,8 @@ type Context struct {
 	ldflags []string // flags passed to the linker
 
 	linkmode, buildmode string // link and build modes
+
+	buildtags []string // build tags
 }
 
 // GOOS configures the Context to use goos as the target os.
@@ -59,6 +61,15 @@ func GOARCH(goarch string) func(*Context) error {
 			return fmt.Errorf("goarch cannot be blank")
 		}
 		c.gotargetarch = goarch
+		return nil
+	}
+}
+
+// Tags configured the context to use these additional build tags
+func Tags(tags ...string) func(*Context) error {
+	return func(c *Context) error {
+		c.buildtags = make([]string, len(tags))
+		copy(c.buildtags, tags)
 		return nil
 	}
 }
@@ -113,6 +124,7 @@ func (p *Project) NewContext(opts ...func(*Context) error) (*Context, error) {
 
 		// Make sure we use the same set of release tags as go/build
 		ReleaseTags: build.Default.ReleaseTags,
+		BuildTags:   ctx.buildtags,
 
 		CgoEnabled: build.Default.CgoEnabled,
 	}
@@ -199,6 +211,7 @@ func (c *Context) ctxString() string {
 		c.gotargetos,
 		c.gotargetarch,
 	}
+	v = append(v, c.buildtags...)
 	return strings.Join(v, "-")
 }
 

--- a/context.go
+++ b/context.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -113,6 +114,9 @@ func (p *Project) NewContext(opts ...func(*Context) error) (*Context, error) {
 			return nil, err
 		}
 	}
+
+	// sort build tags to ensure the ctxSring and Suffix is stable
+	sort.Strings(ctx.buildtags)
 
 	// backfill enbedded go/build.Context
 	ctx.Context = &build.Context{

--- a/context_test.go
+++ b/context_test.go
@@ -35,11 +35,19 @@ func TestLongCycleDetection(t *testing.T) {
 }
 
 func TestContextCtxString(t *testing.T) {
+	opts := func(o ...func(*Context) error) []func(*Context) error { return o }
+	join := func(s ...string) string { return strings.Join(s, "-") }
 	tests := []struct {
 		opts []func(*Context) error
 		want string
 	}{
-		{nil, runtime.GOOS + "-" + runtime.GOARCH},
+		{nil, join(runtime.GOOS, runtime.GOARCH)},
+		{opts(GOOS("windows")), join("windows", runtime.GOARCH)},
+		{opts(GOARCH("arm64")), join(runtime.GOOS, "arm64")},
+		{opts(GOARCH("arm64"), GOOS("plan9")), join("plan9", "arm64")},
+		{opts(Tags()), join(runtime.GOOS, runtime.GOARCH)},
+		{opts(Tags("sphinx", "leon")), join(runtime.GOOS, runtime.GOARCH, "leon", "sphinx")},
+		{opts(Tags("sphinx", "leon"), GOARCH("ppc64le")), join(runtime.GOOS, "ppc64le", "leon", "sphinx")},
 	}
 
 	proj := testProject(t)

--- a/gb.go
+++ b/gb.go
@@ -117,46 +117,6 @@ func joinlist(l []string) string {
 	return strings.Join(l, string(filepath.ListSeparator))
 }
 
-func splitQuotedFields(s string) ([]string, error) {
-	// Split fields allowing '' or "" around elements.
-	// Quotes further inside the string do not count.
-	var f []string
-	for len(s) > 0 {
-		for len(s) > 0 && isWhitespace(s[0]) {
-			s = s[1:]
-		}
-		if len(s) == 0 {
-			break
-		}
-		// Accepted quoted string. No unescaping inside.
-		if s[0] == '"' || s[0] == '\'' {
-			quote := s[0]
-			s = s[1:]
-			i := 0
-			for i < len(s) && s[i] != quote {
-				i++
-			}
-			if i >= len(s) {
-				return nil, fmt.Errorf("unterminated %c string", quote)
-			}
-			f = append(f, s[:i])
-			s = s[i+1:]
-			continue
-		}
-		i := 0
-		for i < len(s) && !isWhitespace(s[i]) {
-			i++
-		}
-		f = append(f, s[:i])
-		s = s[i:]
-	}
-	return f, nil
-}
-
-func isWhitespace(c byte) bool {
-	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
-}
-
 // stripext strips the extension from a filename.
 // The extension is defined by filepath.Ext.
 func stripext(path string) string {

--- a/package.go
+++ b/package.go
@@ -96,6 +96,11 @@ func (pkg *Package) Binfile() string {
 		target += "-" + pkg.ctxString()
 	}
 
+	// append build tags
+	if len(pkg.buildtags) > 0 {
+		target += "-" + strings.Join(pkg.buildtags, "-")
+	}
+
 	if pkg.gotargetos == "windows" {
 		target += ".exe"
 	}

--- a/testdata/src/tags1/t.go
+++ b/testdata/src/tags1/t.go
@@ -1,0 +1,5 @@
+// +build !x
+
+package tags1
+
+const X = 1

--- a/testdata/src/tags2/t.go
+++ b/testdata/src/tags2/t.go
@@ -1,0 +1,5 @@
+// +build x
+
+package tags2
+
+const X = 2


### PR DESCRIPTION
Add support for build tags. Build tags modify the package resolution logic, a la build constraints, build tags also affect staleness computation.

Packages built with tags in effect will be stored in their own package cache. Binaries built with with tags in effect will have the tags appended as a suffix.

Fixes #81 

- [x] extend stringVars to other flags in cmd/gb
- [x] add tests