### PR TITLE
Add ".exe" to the TestPackageBinfile test for windows binaries

### DIFF
--- a/package_test.go
+++ b/package_test.go
@@ -52,6 +52,9 @@ func TestPackageBinfile(t *testing.T) {
 		}
 		got := pkg.Binfile()
 		want := filepath.Join(ctx.Bindir(), tt.want)
+		if pkg.gotargetos == "windows" {
+			want += ".exe"
+		}
 		if want != got {
 			t.Errorf("(%s).Binfile(): want %s, got %s", tt.pkg, want, got)
 		}


### PR DESCRIPTION
Fixes:

```
--- FAIL: TestPackageBinfile (0.00s)
	package_test.go:56: (b).Binfile(): want C:\gopath\src\github.com\constabulary\gb\testdata\bin\b, got C:\gopath\src\github.com\constabulary\gb\testdata\bin\b.exe
```

Not sure if this is the right fix, but I'll let you judge me on that. :smile: