### PR TITLE
vendor: give better error when fetch fails on insecure report import (improvement 1)

### DIFF
--- a/vendor/imports.go
+++ b/vendor/imports.go
@@ -49,23 +49,25 @@ func ParseImports(root string) (map[string]bool, error) {
 }
 
 // FetchMetadata fetchs the remote metadata for path.
-func FetchMetadata(path string, insecure bool) (io.ReadCloser, error) {
+func FetchMetadata(path string, insecure bool) (rc io.ReadCloser, err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("unable to determine remote metadata protocol: %s", err)
+		}
+	}()
 	// try https first
-	r, err := fetchMetadata("https", path)
+	rc, err = fetchMetadata("https", path)
 	if err == nil {
-		return r, nil
+		return
 	}
 	// try http if supported
 	if insecure {
-		r, err := fetchMetadata("http", path)
-		if err != nil {
-			return nil, err
-		}
-		return r, nil
+		rc, err = fetchMetadata("http", path)
+		return
 	} else {
 		log.Infof("skipping insecure protocol: %v", "http")
 	}
-	return nil, fmt.Errorf("unable to determine remote metadata protocol")
+	return
 }
 
 func fetchMetadata(scheme, path string) (io.ReadCloser, error) {

--- a/vendor/imports_test.go
+++ b/vendor/imports_test.go
@@ -85,11 +85,11 @@ go get gopkg.in/check.v1
 	// Test for error catch.
 	errTests := []testParams{{
 		path:     "any.inaccessible.server/the.project",
-		want:     `failed to access url "http://any.inaccessible.server/the.project?go-get=1"`,
+		want:     `unable to determine remote metadata protocol: failed to access url "http://any.inaccessible.server/the.project?go-get=1"`,
 		insecure: true,
 	}, {
 		path:     "any.inaccessible.server/the.project",
-		want:     `unable to determine remote metadata protocol`,
+		want:     `unable to determine remote metadata protocol: failed to access url "https://any.inaccessible.server/the.project?go-get=1"`,
 		insecure: false,
 	}}
 


### PR DESCRIPTION
It will print `unable to determine remote metadata protocol: failed to access url "..."` when fetch fails on insecure report import, no matter what insecure is set or not.