### PR TITLE
Add initial appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,41 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\constabulary\gb
+shallow_clone: true # for startup speed
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+  #- x86
+# the "x86" platform still gives us GOARCH=amd64 :/
+# TODO(tianon) we have 32bit Go installed at C:\go-x86 and 32bit mingw at both C:\msys64\mingw32 and C:\MinGW, so we could do something
+
+# http://www.appveyor.com/docs/installed-software
+install:
+  # some helpful output for debugging builds
+  - go version
+  - go env
+  # pre-installed MinGW at C:\MinGW is 32bit only
+  # but MSYS2 at C:\msys64 has mingw64
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - gcc --version
+  - g++ --version
+  # need bzr for several tests
+  - choco install bzr
+  - set PATH=C:\Program Files (x86)\Bazaar;%PATH%
+  - bzr --version
+  # TODO(tianon) - git clone --depth 1 https://github.com/constabulary/integration-tests.git
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - set PATH=C:\gopath\bin;%PATH%
+  - gb help
+  - go test -v ./...
+
+#artifacts:
+#  - path: '%GOPATH%\bin\*.exe'
+deploy: off


### PR DESCRIPTION
See https://ci.appveyor.com/project/tianon/gb for where I've got this setup on my fork.  I've managed to get the build down to ~2m. :smile:

If you like what you see, setting up AppVeyor should be as simple as creating an account, authorizing them for GitHub, and adding "constabulary/gb" as a project.  I'd also recommend turning on the "ignore branches without `appveyor.yml`" setting, but none of the other settings should be necessary (since they're mostly specified here and having an `appveyor.yml` overrides the entire UI settings anyhow).

I _think_ we can get the integration tests running here too, but that'll take a little more refactoring over in the other repo (especially the `setup.bash` files).