### PR TITLE
Doc tidying: add missing flag docs for list command, line wrapping

### DIFF
--- a/cmd/gb/alldocs.go
+++ b/cmd/gb/alldocs.go
@@ -16,13 +16,13 @@ The commands are:
         generate    generate Go files by processing source
         info        info returns information about this project
         list        list the packages named by the importpaths
-        plugin      run a plugin
         test        test packages
 
 Use "gb help [command]" for more information about a command.
 
 Additional help topics:
 
+        plugin      plugin information
         project     gb project layout
 
 Use "gb help [topic]" for more information about that topic.
@@ -135,15 +135,19 @@ Flags:
 		guarenteed to be stable.
 
 
-Run a plugin
+Plugin information
 
-Usage:
+gb supports git style plugins.
 
-        gb plugin command
+A gb plugin is anything in the $PATH with the prefix gb-. In other words
+gb-something, becomes gb something.
 
-gb supports git style plugins
+gb plugins are executed from the parent gb process with the environment
+variable, GB_PROJECT_DIR set to the root of the current project.
 
-See gb help plugins.
+gb plugins can be executed directly but this is rarely useful, so authors
+should attempt to diagnose this by looking for the presence of the 
+GB_PROJECT_DIR environment key.
 
 
 Gb project layout

--- a/cmd/gb/build.go
+++ b/cmd/gb/build.go
@@ -41,7 +41,7 @@ func addBuildFlags(fs *flag.FlagSet) {
 	// TODO(dfc) this should accept a *gb.Context
 	fs.BoolVar(&A, "a", false, "build all packages in this project")
 	fs.BoolVar(&R, "r", false, "perform a release build")
-	fs.BoolVar(&F, "f", false, "rebuild up to date packages")
+	fs.BoolVar(&F, "f", false, "rebuild up-to-date packages")
 	fs.BoolVar(&FF, "F", false, "do not cache built packages")
 	fs.IntVar(&P, "P", runtime.NumCPU(), "number of parallel jobs")
 	fs.Var((*stringsFlag)(&ldflags), "ldflags", "flags passed to the linker")
@@ -53,16 +53,20 @@ var BuildCmd = &cmd.Command{
 	Name:      "build",
 	Short:     "build a package",
 	UsageLine: "build [build flags] [packages]",
-	Long: `Build compiles the packages named by the import paths, along with their dependencies.
+	Long: `
+Build compiles the packages named by the import paths, along with their
+dependencies.
 
-The build flags are
+Flags:
 
 	-f
-		ignore cached packages if present, new packages built will overwrite any cached packages.
-		This effectively disables incremental compilation.
+		ignore cached packages if present, new packages built will overwrite
+		any cached packages. This effectively disables incremental
+		compilation.
 	-F
-		do not cache packages, cached packages will still be used for incremental compilation.
-		-f -F is advised to disable the package caching system.
+		do not cache packages, cached packages will still be used for
+		incremental compilation. -f -F is advised to disable the package
+		caching system.
 	-q
 		decreases verbosity, effectively raising the output level to ERROR.
 		In a successful build, no output will be displayed.
@@ -70,20 +74,26 @@ The build flags are
 		The number of build jobs to run in parallel, including test execution.
 		By default this is the number of CPUs visible to gb.
 	-R
-		sets the base of the project root search path from the current working directory to the value supplied.
-		Effectively gb changes working directory to this path before searching for the project root.
+		sets the base of the project root search path from the current working
+		directory to the value supplied. Effectively gb changes working
+		directory to this path before searching for the project root.
 	-v
-		increases verbosity, effectively lowering the output level from INFO to DEBUG.
+		increases verbosity, effectively lowering the output level from INFO
+		to DEBUG.
 	-dotfile
-		if provided, gb will output a dot formatted file of the build steps to be performed.
+		if provided, gb will output a dot formatted file of the build steps to
+		be performed.
 	-ldflags 'flag list'
 		arguments to pass on each linker invocation.
 	-gcflags 'arg list'
 		arguments to pass on each go tool compile invocation.
 
-The list flags accept a space-separated list of strings. To embed spaces in an element in the list, surround it with either single or double quotes.
+The list flags accept a space-separated list of strings. To embed spaces in an
+element in the list, surround it with either single or double quotes.
 
-For more about specifying packages, see 'gb help packages'. For more about where packages and binaries are installed, run 'gb help project'.`,
+For more about specifying packages, see 'gb help packages'. For more about
+where packages and binaries are installed, run 'gb help project'.
+`,
 	Run: func(ctx *gb.Context, args []string) error {
 		// TODO(dfc) run should take a *gb.Context not a *gb.Project
 		ctx.Force = F

--- a/cmd/gb/doc.go
+++ b/cmd/gb/doc.go
@@ -15,6 +15,11 @@ func init() {
 		Name:      "doc",
 		UsageLine: `doc <pkg> <sym>[.<method>]`,
 		Short:     "show documentation for a package or symbol",
+		Long: `
+Doc shows documentation for a package or symbol.
+
+See 'go help doc'.
+`,
 		Run: func(ctx *gb.Context, args []string) error {
 			env := cmd.MergeEnv(os.Environ(), map[string]string{
 				"GOPATH": fmt.Sprintf("%s:%s", ctx.Projectdir(), filepath.Join(ctx.Projectdir(), "vendor")),

--- a/cmd/gb/env.go
+++ b/cmd/gb/env.go
@@ -15,8 +15,8 @@ var EnvCmd = &cmd.Command{
 	Name:      "env",
 	UsageLine: `env`,
 	Short:     "print project environment variables",
-	Long: `Env prints project environment variables.
-
+	Long: `
+Env prints project environment variables.
 `,
 	Run: env,
 }

--- a/cmd/gb/generate.go
+++ b/cmd/gb/generate.go
@@ -16,13 +16,16 @@ func init() {
 
 var GenerateCmd = &cmd.Command{
 	Name:      "generate",
-	UsageLine: "generate",
+	UsageLine: "generate [-run regexp] [file.go... | packages]",
 	Short:     "generate Go files by processing source",
-	Long: `Generate runs commands described by directives within existing files.
-Those commands can run any process but the intent is to create or update Go
+	Long: `
+Generate runs commands described by directives within existing files.
+
+Those commands can run any process, but the intent is to create or update Go
 source files, for instance by running yacc.
 
-See 'go help generate'`,
+See 'go help generate'.
+`,
 	Run: func(ctx *gb.Context, args []string) error {
 		env := cmd.MergeEnv(os.Environ(), map[string]string{
 			"GOPATH": fmt.Sprintf("%s:%s", ctx.Projectdir(), filepath.Join(ctx.Projectdir(), "vendor")),

--- a/cmd/gb/list.go
+++ b/cmd/gb/list.go
@@ -27,9 +27,10 @@ func init() {
 		Name:      "list",
 		UsageLine: `list [-s] [-f format] [-json] [packages]`,
 		Short:     "list the packages named by the importpaths",
-		Long: `list lists packages.
+		Long: `
+List lists packages imported by the project.
 
-The default output shows the package import path:
+The default output shows the package import paths:
 
 	% gb list github.com/constabulary/...
 	github.com/constabulary/gb
@@ -43,8 +44,13 @@ Flags:
 		alternate format for the list, using the syntax of package template.
 		The default output is equivalent to -f '{{.ImportPath}}'. The struct
 		being passed to the template is currently an instance of gb.Package.
-		This structure is under active development and it'As contents are not
-		guarenteed to be stable.
+		This structure is under active development and it's contents are not
+		guaranteed to be stable.
+	-s
+		read format template from STDIN.
+	-json
+		prints output in structured JSON format. WARNING: gb.Package
+		structure is not stable and will change in the future!
 `,
 		Run: list,
 		AddFlags: func(fs *flag.FlagSet) {

--- a/cmd/gb/test.go
+++ b/cmd/gb/test.go
@@ -33,13 +33,12 @@ var TestCmd = &cmd.Command{
 	UsageLine: "test [build flags] [packages] [flags for test binary]",
 	Short:     "test packages",
 	Long: `
-'gb test' automates testing the packages named by the import paths.
+Test automates testing the packages named by the import paths.
 
 'gb test' recompiles each package along with any files with names matching
 the file pattern "*_test.go".
 
-See 'go help test'
-
+See 'go help test'.
 `,
 	Run: func(ctx *gb.Context, args []string) error {
 		ctx.Force = F


### PR DESCRIPTION
I noticed that the usage line for `list` showed a few flags that weren't explained. While adding those explanations, I also made line wrapping for some help output that had bugged me on narrower terminals (`build`) consistent with other commands that were nice and pretty, and generally tried to make all the source formatting consistent.

I'm new to gb and just started browsing the source, so there may be some discrepancies I've missed fixing (not sure yet if all the `build` flags are correctly documented), but I think this is a good start.