### PR TITLE
Move ".exe" appending logic into ctx.Suffix()

### DIFF
--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -143,10 +143,10 @@ func TestTestPackages(t *testing.T) {
 		err     error
 	}{{
 		pkgs:    []string{"a", "b", "c"},
-		actions: []string{"run: [$WORKDIR/a/testmain/_test/a$EXE.test]", "run: [$WORKDIR/b/testmain/_test/b$EXE.test]", "run: [$WORKDIR/c/testmain/_test/c$EXE.test]"},
+		actions: []string{"run: [$WORKDIR/a/testmain/_test/a$SUFFIX.test]", "run: [$WORKDIR/b/testmain/_test/b$SUFFIX.test]", "run: [$WORKDIR/c/testmain/_test/c$SUFFIX.test]"},
 	}, {
 		pkgs:    []string{"cgotest", "cgomain", "notestfiles", "cgoonlynotest", "testonly", "extestonly"},
-		actions: []string{"run: [$WORKDIR/cgomain/testmain/_test/cgomain$EXE.test]", "run: [$WORKDIR/cgoonlynotest/testmain/_test/cgoonly$EXE.test]", "run: [$WORKDIR/cgotest/testmain/_test/cgotest$EXE.test]", "run: [$WORKDIR/extestonly/testmain/_test/extestonly$EXE.test]", "run: [$WORKDIR/notestfiles/testmain/_test/notest$EXE.test]", "run: [$WORKDIR/testonly/testmain/_test/testonly$EXE.test]"},
+		actions: []string{"run: [$WORKDIR/cgomain/testmain/_test/cgomain$SUFFIX.test]", "run: [$WORKDIR/cgoonlynotest/testmain/_test/cgoonly$SUFFIX.test]", "run: [$WORKDIR/cgotest/testmain/_test/cgotest$SUFFIX.test]", "run: [$WORKDIR/extestonly/testmain/_test/extestonly$SUFFIX.test]", "run: [$WORKDIR/notestfiles/testmain/_test/notest$SUFFIX.test]", "run: [$WORKDIR/testonly/testmain/_test/testonly$SUFFIX.test]"},
 	}}
 
 	for _, tt := range tests {
@@ -171,14 +171,10 @@ func TestTestPackages(t *testing.T) {
 		}
 		sort.Strings(actual)
 		var expected []string
-		exe := ""
-		if ctx.Context.GOOS == "windows" {
-			exe = ".exe"
-		}
 		for _, s := range tt.actions {
 			s = filepath.FromSlash(s)
 			s = strings.Replace(s, "$WORKDIR", ctx.Workdir(), -1)
-			s = strings.Replace(s, "$EXE", exe, -1)
+			s = strings.Replace(s, "$SUFFIX", ctx.Suffix(), -1)
 			expected = append(expected, s)
 		}
 		if !reflect.DeepEqual(expected, actual) {

--- a/context.go
+++ b/context.go
@@ -155,6 +155,9 @@ func (c *Context) Suffix() string {
 	if suffix != "" {
 		suffix = "-" + suffix
 	}
+	if c.gotargetos == "windows" {
+		suffix += ".exe"
+	}
 	return suffix
 }
 

--- a/package.go
+++ b/package.go
@@ -91,14 +91,8 @@ func (pkg *Package) Binfile() string {
 		target = filepath.Join(pkg.Bindir(), binname(pkg))
 	}
 
-	// if this is a cross compile, add ctxString
-	if pkg.isCrossCompile() {
-		target += "-" + pkg.ctxString()
-	}
+	target += pkg.Context.Suffix()
 
-	if pkg.gotargetos == "windows" {
-		target += ".exe"
-	}
 	return target
 }
 

--- a/package_test.go
+++ b/package_test.go
@@ -51,10 +51,7 @@ func TestPackageBinfile(t *testing.T) {
 			t.Fatal(err)
 		}
 		got := pkg.Binfile()
-		want := filepath.Join(ctx.Bindir(), tt.want)
-		if pkg.gotargetos == "windows" {
-			want += ".exe"
-		}
+		want := filepath.Join(ctx.Bindir(), tt.want+ctx.Suffix())
 		if want != got {
 			t.Errorf("(%s).Binfile(): want %s, got %s", tt.pkg, want, got)
 		}


### PR DESCRIPTION
This also updates the appropriate places in the code to use `ctx.Suffix()` where they weren't previously (and actually, nothing but `gb info` was using it).

One notable place that _doesn't_ change here is `gc.go`, since it's using `gohostos` to find existing tool locations, not dealing with output locations (`gotargetos`).