### PR TITLE
Do not force every package to depend on runtime explicitly

### DIFF
--- a/context.go
+++ b/context.go
@@ -132,6 +132,7 @@ func (p *Project) NewContext(opts ...func(*Context) error) (*Context, error) {
 
 		CgoEnabled: build.Default.CgoEnabled,
 	}
+
 	return &ctx, nil
 }
 

--- a/package.go
+++ b/package.go
@@ -136,14 +136,7 @@ func loadPackage(c *Context, stack []string, path string) (*Package, error) {
 		return nil, err
 	}
 
-	// everything depends on runtime, except the runtime itself.
-	// TODO(dfc) see if this can be made more selective by adding
-	// runtime as a dependency of some select packages.
 	standard := p.Goroot && p.ImportPath != "" && !strings.Contains(p.ImportPath, ".")
-	if standard && p.ImportPath != "runtime" {
-		p.Imports = append(p.Imports, "runtime")
-	}
-
 	push(path)
 	var stale bool
 	for _, i := range p.Imports {


### PR DESCRIPTION
Fixes #323

Forcing every package to have an explicit dependency on the runtime package,
even though 99% of the time they would have a transitive dependency was lame.
It also added many edges to the action graph that were not necessary.

However, the _implicit_ runtime dependency is actually a _link time_ depdendency
not a compile time dependency; pkg runtime must be up to date for the link phase
to run, compilation without linking is not affected.

Realising this we can add the runtime as a depdendency of all _main_ packages,
which reduces the number of redundant edges signficantly.

This also makes it possible to add additional link time depdendencies later, like
math, or runtime/race as required.