### PR TITLE
new package: gb/test

### DIFF
--- a/cmd/gb/build.go
+++ b/cmd/gb/build.go
@@ -103,7 +103,7 @@ For more about where packages and binaries are installed, run 'gb help project'.
 		ctx.Force = F
 		ctx.SkipInstall = FF
 
-		pkgs, err := cmd.ResolvePackages(ctx, args...)
+		pkgs, err := ResolvePackages(ctx, args...)
 		if err != nil {
 			return err
 		}

--- a/cmd/gb/list.go
+++ b/cmd/gb/list.go
@@ -67,7 +67,7 @@ func list(ctx *gb.Context, args []string) error {
 		io.Copy(&formatBuffer, os.Stdin)
 		format = formatBuffer.String()
 	}
-	pkgs, err := cmd.ResolvePackages(ctx, args...)
+	pkgs, err := ResolvePackages(ctx, args...)
 	if err != nil {
 		log.Fatalf("unable to resolve: %v", err)
 	}

--- a/cmd/gb/path.go
+++ b/cmd/gb/path.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"log"
+	"path/filepath"
+
+	"github.com/constabulary/gb"
+)
+
+// RelImportPaths converts a list of potentially relative import path (a path starting with .)
+// to an absolute import path relative to the project root of the Context provided.
+func RelImportPaths(ctx *gb.Context, paths ...string) []string {
+	for i := 0; i < len(paths); i++ {
+		paths[i] = relImportPath(ctx.Srcdirs()[0], paths[i])
+	}
+	return paths
+}
+
+func relImportPath(root, path string) string {
+	if isRel(path) {
+		var err error
+		path, err = filepath.Rel(root, path)
+		if err != nil {
+			log.Fatalf("could not convert relative path %q to absolute: %v", path, err)
+		}
+	}
+	return path
+}
+
+// isRel returns if an import path is relative or absolute.
+func isRel(path string) bool {
+	// TODO(dfc) should this be strings.StartsWith(".")
+	return path == "."
+}

--- a/cmd/gb/resolve.go
+++ b/cmd/gb/resolve.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"fmt"

--- a/cmd/gb/resolve_test.go
+++ b/cmd/gb/resolve_test.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"fmt"
@@ -11,7 +11,7 @@ import (
 
 func TestResolvePackages(t *testing.T) {
 	cwd := getwd(t)
-	root := filepath.Join(cwd, "..", "testdata", "src")
+	root := filepath.Join(cwd, "..", "..", "testdata", "src")
 	tests := []struct {
 		paths []string
 		err   error
@@ -41,7 +41,7 @@ func getwd(t *testing.T) string {
 
 func testProject(t *testing.T) *gb.Project {
 	cwd := getwd(t)
-	root := filepath.Join(cwd, "..", "testdata")
+	root := filepath.Join(cwd, "..", "..", "testdata")
 	return gb.NewProject(root,
 		gb.SourceDir(filepath.Join(root, "src")),
 	)
@@ -57,4 +57,11 @@ func testContext(t *testing.T, opts ...func(*gb.Context) error) *gb.Context {
 	ctx.Force = true
 	ctx.SkipInstall = true
 	return ctx
+}
+
+func sameErr(e1, e2 error) bool {
+	if e1 != nil && e2 != nil {
+		return e1.Error() == e2.Error()
+	}
+	return e1 == e2
 }

--- a/cmd/gb/test.go
+++ b/cmd/gb/test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
+	"github.com/constabulary/gb/test"
 )
 
 func init() {
@@ -43,12 +44,12 @@ See 'go help test'.
 	Run: func(ctx *gb.Context, args []string) error {
 		ctx.Force = F
 		ctx.SkipInstall = FF
-		pkgs, err := cmd.ResolvePackagesWithTests(ctx, args...)
+		pkgs, err := ResolvePackagesWithTests(ctx, args...)
 		if err != nil {
 			return err
 		}
 
-		test, err := cmd.TestPackages(cmd.TestFlags(tfs), pkgs...)
+		test, err := test.TestPackages(TestFlags(tfs), pkgs...)
 		if err != nil {
 			return err
 		}
@@ -67,7 +68,7 @@ See 'go help test'.
 	AddFlags: addTestFlags,
 	FlagParse: func(flags *flag.FlagSet, args []string) error {
 		var err error
-		args, tfs, err = cmd.TestFlagsExtraParse(args[2:])
+		args, tfs, err = TestFlagsExtraParse(args[2:])
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "gb test: %s\n", err)
 			fmt.Fprintf(os.Stderr, `run "go help test" or "go help testflag" for more information`+"\n")

--- a/cmd/gb/testflag.go
+++ b/cmd/gb/testflag.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"errors"

--- a/cmd/gb/testflag_test.go
+++ b/cmd/gb/testflag_test.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"errors"

--- a/cmd/path.go
+++ b/cmd/path.go
@@ -2,11 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
-
-	"github.com/constabulary/gb"
 )
 
 // FindProjectroot works upwards from path seaching for the
@@ -32,30 +29,4 @@ func FindProjectroot(path string) (string, error) {
 		return path, nil
 	}
 	return "", fmt.Errorf("could not find project root in %q or its parents", start)
-}
-
-// RelImportPaths converts a list of potentially relative import path (a path starting with .)
-// to an absolute import path relative to the project root of the Context provided.
-func RelImportPaths(ctx *gb.Context, paths ...string) []string {
-	for i := 0; i < len(paths); i++ {
-		paths[i] = relImportPath(ctx.Srcdirs()[0], paths[i])
-	}
-	return paths
-}
-
-func relImportPath(root, path string) string {
-	if isRel(path) {
-		var err error
-		path, err = filepath.Rel(root, path)
-		if err != nil {
-			log.Fatalf("could not convert relative path %q to absolute: %v", path, err)
-		}
-	}
-	return path
-}
-
-// isRel returns if an import path is relative or absolute.
-func isRel(path string) bool {
-	// TODO(dfc) should this be strings.StartsWith(".")
-	return path == "."
 }

--- a/test/gotest.go
+++ b/test/gotest.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package cmd
+package test
 
 // imported from $GOROOT/src/cmd/go/test.go
 

--- a/test/test.go
+++ b/test/test.go
@@ -1,4 +1,4 @@
-package cmd
+package test
 
 import (
 	"bytes"
@@ -222,4 +222,8 @@ func buildTestMain(pkg *gb.Package) (*gb.Package, error) {
 	testmain.Scope = "test"
 	testmain.ExtraIncludes = filepath.Join(pkg.Workdir(), filepath.FromSlash(pkg.ImportPath), "_test")
 	return testmain, nil
+}
+
+func mkdir(path string) error {
+	return os.MkdirAll(path, 0755)
 }

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -1,6 +1,7 @@
-package cmd
+package test
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -196,4 +197,39 @@ func TestTestPackages(t *testing.T) {
 			t.Errorf("TestBuildPackages(%v): want %v, got %v", pkgs, expected, actual)
 		}
 	}
+}
+
+func getwd(t *testing.T) string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cwd
+}
+
+func testProject(t *testing.T) *gb.Project {
+	cwd := getwd(t)
+	root := filepath.Join(cwd, "..", "testdata")
+	return gb.NewProject(root,
+		gb.SourceDir(filepath.Join(root, "src")),
+	)
+}
+
+func testContext(t *testing.T, opts ...func(*gb.Context) error) *gb.Context {
+	prj := testProject(t)
+	opts = append([]func(*gb.Context) error{gb.GcToolchain()}, opts...)
+	ctx, err := prj.NewContext(opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx.Force = true
+	ctx.SkipInstall = true
+	return ctx
+}
+
+func sameErr(e1, e2 error) bool {
+	if e1 != nil && e2 != nil {
+		return e1.Error() == e2.Error()
+	}
+	return e1 == e2
 }


### PR DESCRIPTION
The goal of not placing the test code directly in gb/ was to demonstrate
that testing did not require tight coupling with gb/ itself -- and this is
true, placing the test code outside gb/ has demonstrated that testing is
a unique function.

However, placing test code inside gb/cmd was a poor choice, and the lesser
evil would be to create yet another package and place the test support code
in that, which is what this PR does.

In the future several things will probably happen.

1. The test code may be integrated into gb/ proper, this would probably be a
net win for the surface area of the greater gb library.
2. The code in gb/cmd will be reduced or eliminated.