### PR TITLE
gb.Resolver interface, remove Srcdirs

### DIFF
--- a/context.go
+++ b/context.go
@@ -180,6 +180,13 @@ func (c *Context) Workdir() string { return c.workdir }
 
 // ResolvePackage resolves the package at path using the current context.
 func (c *Context) ResolvePackage(path string) (*Package, error) {
+	if path == "." {
+		return nil, fmt.Errorf("%q is not a package", filepath.Join(c.rootdir, "src"))
+	}
+	path, err := relImportPath(filepath.Join(c.rootdir, "src"), path)
+	if err != nil {
+		return nil, err
+	}
 	return loadPackage(c, nil, path)
 }
 

--- a/resolve.go
+++ b/resolve.go
@@ -3,15 +3,10 @@ package gb
 import (
 	"fmt"
 	"path/filepath"
-
-	"github.com/constabulary/gb/log"
 )
 
 // Resolver resolves packages.
 type Resolver interface {
-	// Srcdirs returns []string{ "$PROJECT/src", "$PROJECT/vendor/src" }
-	Srcdirs() []string
-
 	// ResolvePackage resolves the import path to a *Package
 	ResolvePackage(path string) (*Package, error)
 }
@@ -20,10 +15,6 @@ type Resolver interface {
 func ResolvePackages(r Resolver, paths ...string) ([]*Package, error) {
 	var pkgs []*Package
 	for _, path := range paths {
-		if path == "." {
-			return nil, fmt.Errorf("%q is not a package", r.Srcdirs()[0])
-		}
-		path = relImportPath(r.Srcdirs()[0], path)
 		pkg, err := r.ResolvePackage(path)
 		if err != nil {
 			return pkgs, fmt.Errorf("failed to resolve import path %q: %v", path, err)
@@ -33,15 +24,11 @@ func ResolvePackages(r Resolver, paths ...string) ([]*Package, error) {
 	return pkgs, nil
 }
 
-func relImportPath(root, path string) string {
+func relImportPath(root, path string) (string, error) {
 	if isRel(path) {
-		var err error
-		path, err = filepath.Rel(root, path)
-		if err != nil {
-			log.Fatalf("could not convert relative path %q to absolute: %v", path, err)
-		}
+		return filepath.Rel(root, path)
 	}
-	return path
+	return path, nil
 }
 
 // isRel returns if an import path is relative or absolute.

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -16,7 +16,7 @@ func TestResolvePackages(t *testing.T) {
 		err   error
 	}{
 		{paths: []string{"a"}},
-		{paths: []string{"."}, err: fmt.Errorf("%q is not a package", root)},
+		{paths: []string{"."}, err: fmt.Errorf("failed to resolve import path %q: %q is not a package", ".", root)},
 		{paths: []string{"h"}, err: fmt.Errorf("failed to resolve import path %q: no buildable Go source files in %s", "h", filepath.Join(root, "blank"))},
 	}
 
@@ -73,7 +73,7 @@ func TestRelImportPath(t *testing.T) {
 
 	for _, tt := range tests {
 
-		got := relImportPath(tt.root, tt.path)
+		got, _ := relImportPath(tt.root, tt.path)
 		if got != tt.want {
 			t.Errorf("relImportPath(%q, %q): want: %v, got: %v", tt.root, tt.path, tt.want, got)
 		}


### PR DESCRIPTION
Remove the Srcdirs method from the resolver interface, making Resolver
a single method interface.