### PR TITLE
log: remove Fatalf

### DIFF
--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -40,6 +40,11 @@ func registerCommand(command *cmd.Command) {
 }
 
 func main() {
+	fatalf := func(format string, args ...interface{}) {
+		fmt.Fprintf(os.Stderr, "FATAL: "+format+"\n", args...)
+		os.Exit(1)
+	}
+
 	args := os.Args
 	if len(args) < 2 || args[1] == "-h" {
 		fs.Usage()
@@ -99,7 +104,7 @@ func main() {
 		err = fs.Parse(args[2:])
 	}
 	if err != nil {
-		log.Fatalf("could not parse flags: %v", err)
+		fatalf("could not parse flags: %v", err)
 	}
 
 	args = fs.Args() // reset args to the leftovers from fs.Parse
@@ -108,7 +113,7 @@ func main() {
 	}
 	cwd, err := filepath.Abs(cwd) // if cwd was passed in via -R, make sure it is absolute
 	if err != nil {
-		log.Fatalf("could not make project root absolute: %v", err)
+		fatalf("could not make project root absolute: %v", err)
 	}
 
 	ctx, err := cmd.NewContext(
@@ -119,7 +124,7 @@ func main() {
 		gb.Tags(buildtags...),
 	)
 	if err != nil {
-		log.Fatalf("unable to construct context: %v", err)
+		fatalf("unable to construct context: %v", err)
 	}
 
 	if !noDestroyContext {
@@ -137,6 +142,6 @@ func main() {
 		if !noDestroyContext {
 			ctx.Destroy()
 		}
-		log.Fatalf("command %q failed: %v", name, err)
+		fatalf("command %q failed: %v", name, err)
 	}
 }

--- a/context.go
+++ b/context.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"go/build"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -101,9 +102,14 @@ func (p *Project) NewContext(opts ...func(*Context) error) (*Context, error) {
 		},
 		GcToolchain(),
 	}
+	workdir, err := ioutil.TempDir("", "gb")
+	if err != nil {
+		return nil, err
+	}
+
 	ctx := Context{
 		Project:   p,
-		workdir:   mktmpdir(),
+		workdir:   workdir,
 		pkgs:      make(map[string]*Package),
 		buildmode: "exe",
 	}

--- a/gb.go
+++ b/gb.go
@@ -7,7 +7,6 @@ package gb
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,14 +62,6 @@ type Action struct {
 
 	// Run identifies the task that this action represents.
 	Run func() error
-}
-
-func mktmpdir() string {
-	d, err := ioutil.TempDir("", "gb")
-	if err != nil {
-		log.Fatalf("could not create temporary directory: %v", err)
-	}
-	return d
 }
 
 func mkdir(path string) error {

--- a/log/log.go
+++ b/log/log.go
@@ -1,9 +1,6 @@
 package log
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
 var (
 	// Quiet suppresses all logging output below ERROR
@@ -12,11 +9,6 @@ var (
 	// Verbose enables logging output below INFO
 	Verbose bool
 )
-
-func Fatalf(format string, args ...interface{}) {
-	fmt.Printf("FATAL "+format+"\n", args...)
-	os.Exit(1)
-}
 
 func Infof(format string, args ...interface{}) {
 	if !Quiet {


### PR DESCRIPTION
Fatalf is unnecessary, and should not be called from anywhere but
the top level of the application.