### PR TITLE
Always capture command output and report package name

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,7 +1,6 @@
 package gb
 
 import (
-	"bytes"
 	"fmt"
 	"go/build"
 	"io"
@@ -211,15 +210,6 @@ func (c *Context) ctxString() string {
 	}
 	v = append(v, c.buildtags...)
 	return strings.Join(v, "-")
-}
-
-func run(dir string, env []string, command string, args ...string) error {
-	var buf bytes.Buffer
-	err := runOut(&buf, dir, env, command, args...)
-	if err != nil {
-		return fmt.Errorf("# %s %s: %v\n%s", command, strings.Join(args, " "), err, buf.String())
-	}
-	return nil
 }
 
 func runOut(output io.Writer, dir string, env []string, command string, args ...string) error {


### PR DESCRIPTION
Fixes #440

Prior to #437 the name of the package under compile or test would be
printed *before* the operation started. This was a problem, because the
compilation output could occur later, and not line up with the package
name.

After #437, package name output was surpressed until the compile/test
action completed successfully. This helped improve the output for tests
but as the overall action, the print would never occur, only the output
to stdout from the child process.

This PR solves the problem at the source by delegating the responsibility
for printing the name of the package before any child output. If all
actions complete, then the final action in the set will print the name
of the package.

As it is now unused, `context.run` has been removed.

TODO:

- [ ] decide if the output should go to stderr, not stdout
- [ ] decide if we should include a # prefix as the go tool does