### PR TITLE
log: remove Infof

### DIFF
--- a/build.go
+++ b/build.go
@@ -209,10 +209,10 @@ func Compile(pkg *Package, deps ...*Action) (*Action, error) {
 	return build, nil
 }
 
-func logInfoFn(fn func() error, format string, args ...interface{}) func() error {
+func logInfoFn(fn func() error, s string) func() error {
 	return func() error {
 		err := fn()
-		log.Infof(format, args...)
+		fmt.Println(s)
 		return err
 	}
 }

--- a/cgo.go
+++ b/cgo.go
@@ -10,8 +10,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/constabulary/gb/log"
 )
 
 func cgo(pkg *Package) (*Action, []string, []string, error) {
@@ -216,8 +214,8 @@ func rungcc1(pkg *Package, cgoCFLAGS []string, ofile, cfile string) error {
 	var buf bytes.Buffer
 	err := runOut(&buf, pkg.Dir, nil, gcc[0], append(gcc[1:], args...)...)
 	if err != nil {
-		log.Infof(pkg.ImportPath)
-		io.Copy(os.Stdout, &buf)
+		fmt.Fprintf(os.Stderr, "# %s\n", pkg.ImportPath)
+		io.Copy(os.Stderr, &buf)
 	}
 	pkg.Record(gcc[0], time.Since(t0))
 	return err
@@ -239,8 +237,8 @@ func rungpp1(pkg *Package, cgoCFLAGS []string, ofile, cfile string) error {
 	var buf bytes.Buffer
 	err := runOut(&buf, pkg.Dir, nil, gxx[0], append(gxx[1:], args...)...)
 	if err != nil {
-		log.Infof(pkg.ImportPath)
-		io.Copy(os.Stdout, &buf)
+		fmt.Fprintf(os.Stderr, "# %s\n", pkg.ImportPath)
+		io.Copy(os.Stderr, &buf)
 	}
 	pkg.Record(gxx[0], time.Since(t0))
 	return err
@@ -263,8 +261,8 @@ func gccld(pkg *Package, cgoCFLAGS, cgoLDFLAGS []string, ofile string, ofiles []
 	var buf bytes.Buffer
 	err := runOut(&buf, pkg.Dir, nil, cmd[0], append(cmd[1:], args...)...)
 	if err != nil {
-		log.Infof(pkg.ImportPath)
-		io.Copy(os.Stdout, &buf)
+		fmt.Fprintf(os.Stderr, "# %s\n", pkg.ImportPath)
+		io.Copy(os.Stderr, &buf)
 	}
 	pkg.Record("gccld", time.Since(t0))
 	return err
@@ -293,8 +291,8 @@ func rungcc3(pkg *Package, dir string, ofile string, ofiles []string) error {
 	var buf bytes.Buffer
 	err := runOut(&buf, dir, nil, cmd[0], append(cmd[1:], args...)...)
 	if err != nil {
-		log.Infof(pkg.ImportPath)
-		io.Copy(os.Stdout, &buf)
+		fmt.Fprintf(os.Stderr, "# %s\n", pkg.ImportPath)
+		io.Copy(os.Stderr, &buf)
 	}
 	pkg.Record("gcc3", time.Since(t0))
 	return err
@@ -412,8 +410,8 @@ func runcgo1(pkg *Package, cflags, ldflags []string) error {
 	var buf bytes.Buffer
 	err := runOut(&buf, pkg.Dir, cgoenv, cgo, args...)
 	if err != nil {
-		log.Infof(pkg.ImportPath)
-		io.Copy(os.Stdout, &buf)
+		fmt.Fprintf(os.Stderr, "# %s\n", pkg.ImportPath)
+		io.Copy(os.Stderr, &buf)
 	}
 	return err
 }
@@ -444,8 +442,8 @@ func runcgo2(pkg *Package, dynout, ofile string) error {
 	var buf bytes.Buffer
 	err := runOut(&buf, pkg.Dir, nil, cgo, args...)
 	if err != nil {
-		log.Infof(pkg.ImportPath)
-		io.Copy(os.Stdout, &buf)
+		fmt.Fprintf(os.Stderr, "# %s\n", pkg.ImportPath)
+		io.Copy(os.Stderr, &buf)
 	}
 	return err
 }

--- a/cmd/gb-vendor/fetch.go
+++ b/cmd/gb-vendor/fetch.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
-	"github.com/constabulary/gb/log"
 	"github.com/constabulary/gb/vendor"
 )
 
@@ -189,7 +188,7 @@ func fetch(ctx *gb.Context, path string, recurse bool) error {
 			keys := keys(missing)
 			sort.Strings(keys)
 			pkg := keys[0]
-			log.Infof("fetching recursive dependency %s", pkg)
+			fmt.Println("fetching recursive dependency", pkg)
 			if err := fetch(ctx, pkg, false); err != nil {
 				return err
 			}

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -24,7 +24,6 @@ const (
 )
 
 func init() {
-	fs.BoolVar(&log.Quiet, "q", log.Quiet, "suppress log messages below ERROR level")
 	fs.BoolVar(&log.Verbose, "v", log.Verbose, "enable log levels below INFO level")
 	fs.StringVar(&cwd, "R", cmd.MustGetwd(), "set the project root") // actually the working directory to start the project root search
 

--- a/gc.go
+++ b/gc.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-
-	"github.com/constabulary/gb/log"
 )
 
 // gc toolchain
@@ -80,8 +78,8 @@ func (t *gcToolchain) Asm(pkg *Package, srcdir, ofile, sfile string) error {
 	var buf bytes.Buffer
 	err := runOut(&buf, srcdir, nil, t.as, args...)
 	if err != nil {
-		log.Infof(pkg.ImportPath)
-		io.Copy(os.Stdout, &buf)
+		fmt.Fprintf(os.Stderr, "# %s\n", pkg.ImportPath)
+		io.Copy(os.Stderr, &buf)
 	}
 	return err
 }
@@ -101,8 +99,8 @@ func (t *gcToolchain) Ld(pkg *Package, searchpaths []string, outfile, afile stri
 	var buf bytes.Buffer
 	err := runOut(&buf, ".", nil, t.ld, args...)
 	if err != nil {
-		log.Infof(pkg.ImportPath)
-		io.Copy(os.Stdout, &buf)
+		fmt.Fprintf(os.Stderr, "# %s\n", pkg.ImportPath)
+		io.Copy(os.Stderr, &buf)
 	}
 	return err
 }
@@ -124,8 +122,8 @@ func (t *gcToolchain) Cc(pkg *Package, ofile, cfile string) error {
 	var buf bytes.Buffer
 	err := runOut(&buf, pkg.Dir, nil, t.cc, args...)
 	if err != nil {
-		log.Infof(pkg.ImportPath)
-		io.Copy(os.Stdout, &buf)
+		fmt.Fprintf(os.Stderr, "# %s\n", pkg.ImportPath)
+		io.Copy(os.Stderr, &buf)
 	}
 	return err
 }
@@ -137,8 +135,8 @@ func (t *gcToolchain) Pack(pkg *Package, afiles ...string) error {
 	var buf bytes.Buffer
 	err := runOut(&buf, dir, nil, t.pack, args...)
 	if err != nil {
-		log.Infof(pkg.ImportPath)
-		io.Copy(os.Stdout, &buf)
+		fmt.Fprintf(os.Stderr, "# %s\n", pkg.ImportPath)
+		io.Copy(os.Stderr, &buf)
 	}
 	return err
 }
@@ -172,8 +170,8 @@ func (t *gcToolchain) Gc(pkg *Package, searchpaths []string, importpath, srcdir,
 	var buf bytes.Buffer
 	err := runOut(&buf, srcdir, nil, t.gc, args...)
 	if err != nil {
-		log.Infof(pkg.ImportPath)
-		io.Copy(os.Stdout, &buf)
+		fmt.Fprintf(os.Stderr, "# %s\n", pkg.ImportPath)
+		io.Copy(os.Stderr, &buf)
 	}
 	return err
 }

--- a/log/log.go
+++ b/log/log.go
@@ -3,25 +3,12 @@ package log
 import "fmt"
 
 var (
-	// Quiet suppresses all logging output below ERROR
-	Quiet bool
-
-	// Verbose enables logging output below INFO
+	// Verbose enables Debug logging
 	Verbose bool
 )
 
-func Infof(format string, args ...interface{}) {
-	if !Quiet {
-		if Verbose {
-			fmt.Printf("INFO "+format+"\n", args...)
-		} else {
-			fmt.Printf(format+"\n", args...)
-		}
-	}
-}
-
 func Debugf(format string, args ...interface{}) {
-	if Verbose && !Quiet {
+	if Verbose {
 		fmt.Printf("DEBUG "+format+"\n", args...)
 	}
 }

--- a/test/test.go
+++ b/test/test.go
@@ -174,9 +174,11 @@ func TestPackage(targets map[string]*gb.Action, pkg *gb.Package, flags []string)
 	logInfoFn := func(fn func() error, format string, args ...interface{}) func() error {
 		return func() error {
 			err := fn()
-			log.Infof(format, args...)
 			if err != nil {
+				fmt.Fprintf(os.Stderr, "# %s\n", pkg.ImportPath)
 				io.Copy(os.Stdout, &output)
+			} else {
+				fmt.Println(pkg.ImportPath)
 			}
 			return err
 		}

--- a/vendor/repo.go
+++ b/vendor/repo.go
@@ -11,8 +11,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-
-	"github.com/constabulary/gb/log"
 )
 
 // RemoteRepo describes a remote dvcs repository.
@@ -248,7 +246,7 @@ func probe(vcs func(*url.URL) error, url *url.URL, insecure bool, schemes ...str
 			}
 		case "http", "git":
 			if !insecure {
-				log.Infof("skipping insecure protocol: %s", url.String())
+				fmt.Println("skipping insecure protocol:", url.String())
 				continue
 			}
 			if err := vcs(&url); err == nil {


### PR DESCRIPTION
The uses of gb/log are so simple now that there is no value in having
a log.Info wrapper around fmt.

At the same time, address the remaining TODO items on #442.

- [x] compile/test failures are now with a # prefix,  this matches the
      go tools observed behaviour.
- [x] failures go to os.Stderr, successes go to os.Stdout.

Finally, remove log.Quiet flag as there is no ERROR level, nor INFO level.
gb users should pipe the appropriate fd's to /dev/null to adjust the
verbosity level of cmd/gb.