### PR TITLE
Show vendor plugin help when no command is given

### DIFF
--- a/cmd/gb-vendor/main.go
+++ b/cmd/gb-vendor/main.go
@@ -18,10 +18,7 @@ var (
 )
 
 func init() {
-	fs.Usage = func() {
-		printUsage(os.Stderr)
-		os.Exit(2)
-	}
+	fs.Usage = usage
 }
 
 var commands = []*cmd.Command{
@@ -43,8 +40,8 @@ func main() {
 
 	switch {
 	case len(args) < 1, args[0] == "-h", args[0] == "-help":
-		fs.Usage()
-		os.Exit(1)
+		printUsage(os.Stdout)
+		os.Exit(0)
 	case args[0] == "help":
 		help(args[1:])
 		return

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -63,9 +63,6 @@ func main() {
 		}
 		command = &cmd.Command{
 			Run: func(ctx *gb.Context, args []string) error {
-				if len(args) < 1 {
-					return fmt.Errorf("plugin: no command supplied")
-				}
 				args = append([]string{plugin}, args...)
 
 				env := cmd.MergeEnv(os.Environ(), map[string]string{


### PR DESCRIPTION
I don't have much familiarity with gb internals, but I use it a lot and saw the "Help Wanted" sign.  This PR may not be exactly what you're looking for. I couldn't come up with a good reason why args < 1 should cause an error at the gb level... why not let the plugins worry about that?  Also, the various exit codes in gb-vendor were causing ugly "FATAL: ..." at the end of the help, so I pulled them.

Fixes #446