### PR TITLE
debug: debug logging refactoring

### DIFF
--- a/build.go
+++ b/build.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/constabulary/gb/log"
+	"github.com/constabulary/gb/debug"
 )
 
 // Build builds each of pkgs in succession. If pkg is a command, then the results of build include
@@ -45,14 +45,14 @@ func BuildPackages(pkgs ...*Package) (*Action, error) {
 	build := Action{
 		Name: fmt.Sprintf("build: %s", strings.Join(names(pkgs), ",")),
 		Run: func() error {
-			log.Debugf("build duration: %v %v", time.Since(t0), pkgs[0].Statistics.String())
+			debug.Debugf("build duration: %v %v", time.Since(t0), pkgs[0].Statistics.String())
 			return nil
 		},
 	}
 
 	for _, pkg := range pkgs {
 		if len(pkg.GoFiles)+len(pkg.CgoFiles) == 0 {
-			log.Debugf("skipping %v: no go files", pkg.ImportPath)
+			debug.Debugf("skipping %v: no go files", pkg.ImportPath)
 			continue
 		}
 		a, err := BuildPackage(targets, pkg)

--- a/build_test.go
+++ b/build_test.go
@@ -11,12 +11,12 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/constabulary/gb/log"
+	"github.com/constabulary/gb/debug"
 )
 
 func TestBuild(t *testing.T) {
-	log.Verbose = false
-	defer func() { log.Verbose = false }()
+	debug.Verbose = false
+	defer func() { debug.Verbose = false }()
 
 	opts := func(o ...func(*Context) error) []func(*Context) error { return o }
 	tests := []struct {
@@ -97,8 +97,8 @@ func TestBuild(t *testing.T) {
 }
 
 func TestBuildPackage(t *testing.T) {
-	log.Verbose = false
-	defer func() { log.Verbose = false }()
+	debug.Verbose = false
+	defer func() { debug.Verbose = false }()
 	tests := []struct {
 		pkg string
 		err error
@@ -150,8 +150,8 @@ func TestBuildPackage(t *testing.T) {
 }
 
 func TestBuildPackages(t *testing.T) {
-	log.Verbose = false
-	defer func() { log.Verbose = false }()
+	debug.Verbose = false
+	defer func() { debug.Verbose = false }()
 	tests := []struct {
 		pkgs    []string
 		actions []string

--- a/build_test.go
+++ b/build_test.go
@@ -10,14 +10,9 @@ import (
 	"reflect"
 	"sort"
 	"testing"
-
-	"github.com/constabulary/gb/debug"
 )
 
 func TestBuild(t *testing.T) {
-	debug.Verbose = false
-	defer func() { debug.Verbose = false }()
-
 	opts := func(o ...func(*Context) error) []func(*Context) error { return o }
 	tests := []struct {
 		pkg  string
@@ -97,8 +92,6 @@ func TestBuild(t *testing.T) {
 }
 
 func TestBuildPackage(t *testing.T) {
-	debug.Verbose = false
-	defer func() { debug.Verbose = false }()
 	tests := []struct {
 		pkg string
 		err error
@@ -150,8 +143,6 @@ func TestBuildPackage(t *testing.T) {
 }
 
 func TestBuildPackages(t *testing.T) {
-	debug.Verbose = false
-	defer func() { debug.Verbose = false }()
 	tests := []struct {
 		pkgs    []string
 		actions []string

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/constabulary/gb"
-	"github.com/constabulary/gb/log"
+	"github.com/constabulary/gb/debug"
 )
 
 // Command represents a subcommand, or plugin that is executed within
@@ -66,7 +66,7 @@ func RunCommand(fs *flag.FlagSet, cmd *Command, projectroot, goroot string, args
 	}
 	defer ctx.Destroy()
 
-	log.Debugf("args: %v", args)
+	debug.Debugf("args: %v", args)
 	return cmd.Run(ctx, args)
 }
 
@@ -85,7 +85,7 @@ func NewContext(projectroot string, options ...func(*gb.Context) error) (*gb.Con
 		gb.SourceDir(filepath.Join(root, "vendor", "src")),
 	)
 
-	log.Debugf("project root %q", project.Projectdir())
+	debug.Debugf("project root %q", project.Projectdir())
 	return project.NewContext(options...)
 }
 

--- a/cmd/gb-vendor/main.go
+++ b/cmd/gb-vendor/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
-	"github.com/constabulary/gb/log"
+	"github.com/constabulary/gb/debug"
 )
 
 var (
@@ -59,8 +59,10 @@ func main() {
 	}
 	project := gb.NewProject(root,
 		gb.SourceDir(filepath.Join(root, "src")),
-		gb.SourceDir(filepath.Join(root, "vendor", "src")))
-	log.Debugf("project root %q", project.Projectdir())
+		gb.SourceDir(filepath.Join(root, "vendor", "src")),
+	)
+
+	debug.Debugf("project root %q", project.Projectdir())
 
 	for _, command := range commands {
 		if command.Name == args[0] && command.Runnable() {
@@ -79,7 +81,7 @@ func main() {
 				fatalf("could not parse flags: %v", err)
 			}
 			args = fs.Args() // reset args to the leftovers from fs.Parse
-			log.Debugf("args: %v", args)
+			debug.Debugf("args: %v", args)
 
 			ctx, err := project.NewContext(
 				gb.GcToolchain(),

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
-	"github.com/constabulary/gb/log"
+	"github.com/constabulary/gb/debug"
 )
 
 var (
@@ -24,7 +24,7 @@ const (
 )
 
 func init() {
-	fs.BoolVar(&log.Verbose, "v", log.Verbose, "enable log levels below INFO level")
+	fs.BoolVar(&debug.Verbose, "v", debug.Verbose, "enable log levels below INFO level")
 	fs.StringVar(&cwd, "R", cmd.MustGetwd(), "set the project root") // actually the working directory to start the project root search
 
 	fs.Usage = usage
@@ -136,7 +136,7 @@ func main() {
 		args = cmd.ImportPaths(ctx, cwd, args)
 	}
 
-	log.Debugf("args: %v", args)
+	debug.Debugf("args: %v", args)
 	if err := command.Run(ctx, args); err != nil {
 		if !noDestroyContext {
 			ctx.Destroy()

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -24,9 +24,7 @@ const (
 )
 
 func init() {
-	fs.BoolVar(&debug.Verbose, "v", debug.Verbose, "enable log levels below INFO level")
 	fs.StringVar(&cwd, "R", cmd.MustGetwd(), "set the project root") // actually the working directory to start the project root search
-
 	fs.Usage = usage
 }
 

--- a/context.go
+++ b/context.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/constabulary/gb/log"
+	"github.com/constabulary/gb/debug"
 )
 
 // Context represents an execution of one or more Targets inside a Project.
@@ -197,7 +197,7 @@ func (c *Context) ResolvePackage(path string) (*Package, error) {
 
 // Destroy removes the temporary working files of this context.
 func (c *Context) Destroy() error {
-	log.Debugf("removing work directory: %v", c.workdir)
+	debug.Debugf("removing work directory: %v", c.workdir)
 	return os.RemoveAll(c.workdir)
 }
 
@@ -218,7 +218,7 @@ func runOut(output io.Writer, dir string, env []string, command string, args ...
 	cmd.Stdout = output
 	cmd.Stderr = os.Stderr
 	cmd.Env = mergeEnvLists(env, envForDir(cmd.Dir))
-	log.Debugf("cd %s; %s", cmd.Dir, cmd.Args)
+	debug.Debugf("cd %s; %s", cmd.Dir, cmd.Args)
 	err := cmd.Run()
 	return err
 }
@@ -321,7 +321,7 @@ func (c *Context) isCrossCompile() bool {
 }
 
 func matchPackages(c *Context, pattern string) []string {
-	log.Debugf("matchPackages: %v %v", c.srcdirs[0].Root, pattern)
+	debug.Debugf("matchPackages: %v %v", c.srcdirs[0].Root, pattern)
 	match := func(string) bool { return true }
 	treeCanMatch := func(string) bool { return true }
 	if pattern != "all" && pattern != "std" {

--- a/debug/debug.go
+++ b/debug/debug.go
@@ -1,4 +1,4 @@
-package log
+package debug
 
 import "fmt"
 

--- a/debug/debug.go
+++ b/debug/debug.go
@@ -1,14 +1,28 @@
+// debug provides a light weight debug facility.
+// Usage is via the DEBUG environment variable. Any non empty value will
+// enable debug logging. For example
+//
+//     DEBUG=. gb
+//
+// The period is a hint that the value passed to DEBUG is a regex, which matches
+// files, or packages present in the file part of the file/line pair logged as a
+// prefix of the log line. (not implemented yet)
+//
+// Debug output is send to os.Stderr, there is no facility to change this.
 package debug
 
-import "fmt"
-
-var (
-	// Verbose enables Debug logging
-	Verbose bool
+import (
+	"log"
+	"os"
 )
 
+var debug = os.Getenv("DEBUG")
+
+var logger = log.New(os.Stderr, "", log.Ldate|log.Ltime|log.Lshortfile)
+
 func Debugf(format string, args ...interface{}) {
-	if Verbose {
-		fmt.Printf("DEBUG "+format+"\n", args...)
+	if len(debug) == 0 {
+		return
 	}
+	logger.Printf(format, args...)
 }

--- a/gb.go
+++ b/gb.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/constabulary/gb/log"
+	"github.com/constabulary/gb/debug"
 )
 
 // Toolchain represents a standardised set of command line tools
@@ -83,7 +83,7 @@ func copyfile(dst, src string) error {
 		return fmt.Errorf("copyfile: create(%q): %v", dst, err)
 	}
 	defer w.Close()
-	log.Debugf("copyfile(dst: %v, src: %v)", dst, src)
+	debug.Debugf("copyfile(dst: %v, src: %v)", dst, src)
 	_, err = io.Copy(w, r)
 	return err
 }

--- a/test/gotest.go
+++ b/test/gotest.go
@@ -24,7 +24,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/constabulary/gb"
-	"github.com/constabulary/gb/log"
+	"github.com/constabulary/gb/debug"
 )
 
 type coverInfo struct {
@@ -92,7 +92,7 @@ func loadTestFuncs(ptest *build.Package) (*testFuncs, error) {
 	t := &testFuncs{
 		Package: ptest,
 	}
-	log.Debugf("loadTestFuncs: %v, %v", ptest.TestGoFiles, ptest.XTestGoFiles)
+	debug.Debugf("loadTestFuncs: %v, %v", ptest.TestGoFiles, ptest.XTestGoFiles)
 	for _, file := range ptest.TestGoFiles {
 		if err := t.load(filepath.Join(ptest.Dir, file), "_test", &t.ImportTest, &t.NeedTest); err != nil {
 			return nil, err

--- a/test/test.go
+++ b/test/test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/constabulary/gb"
-	"github.com/constabulary/gb/log"
+	"github.com/constabulary/gb/debug"
 )
 
 // Test returns a Target representing the result of compiling the
@@ -48,7 +48,7 @@ func TestPackages(flags []string, pkgs ...*gb.Package) (*gb.Action, error) {
 	test := gb.Action{
 		Name: fmt.Sprintf("test: %s", strings.Join(names(pkgs), ",")),
 		Run: func() error {
-			log.Debugf("test duration: %v %v", time.Since(t0), pkgs[0].Statistics.String())
+			debug.Debugf("test duration: %v %v", time.Since(t0), pkgs[0].Statistics.String())
 			return nil
 		},
 	}

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -10,12 +10,12 @@ import (
 	"time"
 
 	"github.com/constabulary/gb"
-	"github.com/constabulary/gb/log"
+	"github.com/constabulary/gb/debug"
 )
 
 func TestTest(t *testing.T) {
-	log.Verbose = false
-	defer func() { log.Verbose = false }()
+	debug.Verbose = false
+	defer func() { debug.Verbose = false }()
 	tests := []struct {
 		pkg      string
 		testArgs []string

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -10,12 +10,9 @@ import (
 	"time"
 
 	"github.com/constabulary/gb"
-	"github.com/constabulary/gb/debug"
 )
 
 func TestTest(t *testing.T) {
-	debug.Verbose = false
-	defer func() { debug.Verbose = false }()
 	tests := []struct {
 		pkg      string
 		testArgs []string


### PR DESCRIPTION
This PR adds basic support for improved debugging support.

- gb/log was renamed to gb/debug to reflect the fact it is only involved in debug logging.
- the `-v` flag is removed from cmd/gb, info logging is controlled by piping stdout to /dev/null.
- debug support now lists file and line numbers, packages are elided.
- DEBUG takes a regex, but the regex is ignored, any non empty value will enable debugging unconditionally.