### PR TITLE
vendor: reactivate bitbucket tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
   - echo '#!/bin/bash' > "$GOPATH/bin/sudo"
     && echo 'echo >&2 attempted sudo "$@"' >> "$GOPATH/bin/sudo"
     && chmod +x "$GOPATH/bin/sudo"
+  - ssh -o StrictHostKeyChecking=no bitbucket.org || true
 
 script:
   - go test -v ./...

--- a/vendor/repo.go
+++ b/vendor/repo.go
@@ -379,6 +379,7 @@ func (h *hgrepo) Checkout(branch, tag, revision string) (WorkingCopy, error) {
 		"clone",
 		h.url,
 		dir,
+		"--noninteractive",
 	}
 
 	if branch != "" {
@@ -499,6 +500,7 @@ func run(c string, args ...string) ([]byte, error) {
 
 func runOut(w io.Writer, c string, args ...string) error {
 	cmd := exec.Command(c, args...)
+	cmd.Stdin = nil
 	cmd.Stdout = w
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
@@ -513,6 +515,7 @@ func runPath(path string, c string, args ...string) ([]byte, error) {
 func runOutPath(w io.Writer, path string, c string, args ...string) error {
 	cmd := exec.Command(c, args...)
 	cmd.Dir = path
+	cmd.Stdin = nil
 	cmd.Stdout = w
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/vendor/repo_test.go
+++ b/vendor/repo_test.go
@@ -44,7 +44,7 @@ func TestDeduceRemoteRepo(t *testing.T) {
 			url: "https://github.com/coreos/go-etcd",
 		},
 	}, {
-/*		path: "bitbucket.org/davecheney/gitrepo/cmd/main",
+		path: "bitbucket.org/davecheney/gitrepo/cmd/main",
 		want: &gitrepo{
 			url: "https://bitbucket.org/davecheney/gitrepo",
 		},
@@ -55,7 +55,7 @@ func TestDeduceRemoteRepo(t *testing.T) {
 			url: "https://bitbucket.org/davecheney/hgrepo",
 		},
 		extra: "/cmd/main",
-	}, { */
+	}, {
 		path: "code.google.com/p/goauth2/oauth",
 		want: &hgrepo{
 			url: "https://code.google.com/p/goauth2",


### PR DESCRIPTION
Fixes #452

Because of reasons bitbucket.org is not in the ssh known hosts' file in tavis.yml. This leaves two questions

1. why does it appear to be in the ssh hosts' file on the other CI providers
2. why, even though we assign /dev/null to Stdin, does mercurial still prompt for an answer

Having no good answer for both, try to work around the problem by pre-populating the known hosts file during setup. 