### PR TITLE
cmd/gb: catch signals during build and test

### DIFF
--- a/build.go
+++ b/build.go
@@ -17,7 +17,7 @@ func Build(pkgs ...*Package) error {
 	if err != nil {
 		return err
 	}
-	return ExecuteConcurrent(build, runtime.NumCPU())
+	return ExecuteConcurrent(build, runtime.NumCPU(), nil)
 }
 
 // BuildPackages produces a tree of *Actions that can be executed to build

--- a/cmd/gb/build.go
+++ b/cmd/gb/build.go
@@ -120,7 +120,7 @@ For more about where packages and binaries are installed, run 'gb help project'.
 		}
 
 		startSigHandlers()
-		return gb.ExecuteConcurrent(build, P)
+		return gb.ExecuteConcurrent(build, P, interrupted)
 	},
 	AddFlags: addBuildFlags,
 }

--- a/cmd/gb/build.go
+++ b/cmd/gb/build.go
@@ -119,6 +119,7 @@ For more about where packages and binaries are installed, run 'gb help project'.
 			printActions(f, build)
 		}
 
+		startSigHandlers()
 		return gb.ExecuteConcurrent(build, P)
 	},
 	AddFlags: addBuildFlags,

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -36,12 +36,12 @@ func registerCommand(command *cmd.Command) {
 	commands[command.Name] = command
 }
 
-func main() {
-	fatalf := func(format string, args ...interface{}) {
-		fmt.Fprintf(os.Stderr, "FATAL: "+format+"\n", args...)
-		os.Exit(1)
-	}
+func fatalf(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, "FATAL: "+format+"\n", args...)
+	os.Exit(1)
+}
 
+func main() {
 	args := os.Args
 	if len(args) < 2 || args[1] == "-h" {
 		fs.Usage()
@@ -134,8 +134,9 @@ func main() {
 	debug.Debugf("args: %v", args)
 	if err := command.Run(ctx, args); err != nil {
 		if !noDestroyContext {
-			ctx.Destroy()
+			defer ctx.Destroy()
 		}
 		fatalf("command %q failed: %v", name, err)
 	}
+	return
 }

--- a/cmd/gb/signal.go
+++ b/cmd/gb/signal.go
@@ -1,0 +1,31 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+)
+
+// interrupted is closed, if go process is interrupted.
+var interrupted = make(chan struct{})
+
+// processSignals setups signal handler.
+func processSignals() {
+	sig := make(chan os.Signal)
+	signal.Notify(sig, signalsToIgnore...)
+	go func() {
+		<-sig
+		close(interrupted)
+	}()
+}
+
+var onceProcessSignals sync.Once
+
+// startSigHandlers start signal handlers.
+func startSigHandlers() {
+	onceProcessSignals.Do(processSignals)
+}

--- a/cmd/gb/signal_notunix.go
+++ b/cmd/gb/signal_notunix.go
@@ -1,0 +1,17 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build plan9 windows
+
+package main
+
+import (
+	"os"
+)
+
+var signalsToIgnore = []os.Signal{os.Interrupt}
+
+// signalTrace is the signal to send to make a Go program
+// crash with a stack trace.
+var signalTrace os.Signal = nil

--- a/cmd/gb/signal_unix.go
+++ b/cmd/gb/signal_unix.go
@@ -1,0 +1,18 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+var signalsToIgnore = []os.Signal{os.Interrupt, syscall.SIGQUIT}
+
+// signalTrace is the signal to send to make a Go program
+// crash with a stack trace.
+var signalTrace os.Signal = syscall.SIGQUIT

--- a/cmd/gb/test.go
+++ b/cmd/gb/test.go
@@ -72,6 +72,7 @@ See 'go help test'.
 			printActions(f, test)
 		}
 
+		startSigHandlers()
 		return gb.ExecuteConcurrent(test, P)
 	},
 	AddFlags: addTestFlags,

--- a/cmd/gb/test.go
+++ b/cmd/gb/test.go
@@ -73,7 +73,7 @@ See 'go help test'.
 		}
 
 		startSigHandlers()
-		return gb.ExecuteConcurrent(test, P)
+		return gb.ExecuteConcurrent(test, P, interrupted)
 	},
 	AddFlags: addTestFlags,
 	FlagParse: func(flags *flag.FlagSet, args []string) error {

--- a/executor.go
+++ b/executor.go
@@ -1,6 +1,7 @@
 package gb
 
 import (
+	"errors"
 	"sync"
 )
 
@@ -31,7 +32,7 @@ func execute(seen map[*Action]error, a *Action) error {
 
 // ExecuteConcurrent executes all actions in a tree concurrently.
 // Each Action will wait until its dependant actions are complete.
-func ExecuteConcurrent(a *Action, n int) error {
+func ExecuteConcurrent(a *Action, n int, interrupt <-chan struct{}) error {
 	var mu sync.Mutex // protects seen
 	seen := make(map[*Action]chan error)
 
@@ -83,9 +84,14 @@ func ExecuteConcurrent(a *Action, n int) error {
 				}
 			}
 			// wait for a permit and execute our action
-			<-permits
-			result <- a.Run()
-			permits <- true
+			select {
+			case <-permits:
+				result <- a.Run()
+				permits <- true
+			case <-interrupt:
+				result <- errors.New("interrupted")
+				return
+			}
 		}()
 
 		return result

--- a/executor_test.go
+++ b/executor_test.go
@@ -155,7 +155,7 @@ func TestExecute(t *testing.T) {
 func testExecuteConcurrentN(t *testing.T, n int) {
 	for _, tt := range executorTests {
 		executeReset()
-		got := ExecuteConcurrent(tt.action, n)
+		got := ExecuteConcurrent(tt.action, n, nil) // no interrupt ch
 		if !reflect.DeepEqual(got, tt.err) {
 			t.Errorf("ExecuteConcurrent(%v): %v: want err: %v, got err %v", n, tt.action.Name, tt.err, got)
 		}


### PR DESCRIPTION
This is the logic that Alex Brainman and I added to cmd/go back in Go 1.0. It's not perfect, but it's worked well enough for the last few years.
 
### Todo
- [x] gb.Executors need to take some kind of reference to the interrupted channel so it can shutdown
- [ ] No tests for interruption yet

Fixes #436
Updates #445