### PR TITLE
gb/test: refactor execution of test binary

### DIFF
--- a/test/test_test.go
+++ b/test/test_test.go
@@ -142,19 +142,19 @@ func TestTestPackages(t *testing.T) {
 	}{{
 		pkgs: []string{"a", "b", "c"},
 		actions: []string{
-			"run: [$WORKDIR/a/testmain/_test/a.test$EXE]",
-			"run: [$WORKDIR/b/testmain/_test/b.test$EXE]",
-			"run: [$WORKDIR/c/testmain/_test/c.test$EXE]",
+			"run: $WORKDIR/a/testmain/_test/a.test$EXE",
+			"run: $WORKDIR/b/testmain/_test/b.test$EXE",
+			"run: $WORKDIR/c/testmain/_test/c.test$EXE",
 		},
 	}, {
 		pkgs: []string{"cgotest", "cgomain", "notestfiles", "cgoonlynotest", "testonly", "extestonly"},
 		actions: []string{
-			"run: [$WORKDIR/cgomain/testmain/_test/cgomain.test$EXE]",
-			"run: [$WORKDIR/cgoonlynotest/testmain/_test/cgoonly.test$EXE]",
-			"run: [$WORKDIR/cgotest/testmain/_test/cgotest.test$EXE]",
-			"run: [$WORKDIR/extestonly/testmain/_test/extestonly.test$EXE]",
-			"run: [$WORKDIR/notestfiles/testmain/_test/notest.test$EXE]",
-			"run: [$WORKDIR/testonly/testmain/_test/testonly.test$EXE]",
+			"run: $WORKDIR/cgomain/testmain/_test/cgomain.test$EXE",
+			"run: $WORKDIR/cgoonlynotest/testmain/_test/cgoonly.test$EXE",
+			"run: $WORKDIR/cgotest/testmain/_test/cgotest.test$EXE",
+			"run: $WORKDIR/extestonly/testmain/_test/extestonly.test$EXE",
+			"run: $WORKDIR/notestfiles/testmain/_test/notest.test$EXE",
+			"run: $WORKDIR/testonly/testmain/_test/testonly.test$EXE",
 		},
 	}}
 


### PR DESCRIPTION
Update #448

The previous method of destructuring actions into multiple nested
anon functions was cute, but overcomplicated. It might also have
been wrong, and was causing #448.