### PR TITLE
build: add support for .syso files

### DIFF
--- a/build.go
+++ b/build.go
@@ -155,6 +155,11 @@ func Compile(pkg *Package, deps ...*Action) (*Action, error) {
 		ofiles = append(ofiles, ofile)
 	}
 
+	// step 4. add system object files.
+	for _, syso := range pkg.SysoFiles {
+		ofiles = append(ofiles, filepath.Join(pkg.Dir, syso))
+	}
+
 	build := &compile
 
 	// Do we need to pack ? Yes, replace build action with pack.

--- a/cgo.go
+++ b/cgo.go
@@ -69,6 +69,7 @@ func cgo14(pkg *Package) (*Action, []string, []string, error) {
 	cflags := append(cgoCPPFLAGS, cgoCFLAGS...)
 	cxxflags := append(cgoCPPFLAGS, cgoCXXFLAGS...)
 	gcc1, ofiles := cgocc(pkg, cflags, cxxflags, cfiles, pkg.CXXFiles, runcgo1...)
+	ofiles = append(ofiles, pkg.SysoFiles...)
 	ofile := filepath.Join(filepath.Dir(ofiles[0]), "_cgo_.o")
 	gcc2 := Action{
 		Name: "gccld: " + pkg.ImportPath + ": _cgo_.o",
@@ -140,6 +141,7 @@ func cgo15(pkg *Package) (*Action, []string, []string, error) {
 	cflags := append(cgoCPPFLAGS, cgoCFLAGS...)
 	cxxflags := append(cgoCPPFLAGS, cgoCXXFLAGS...)
 	gcc1, ofiles := cgocc(pkg, cflags, cxxflags, cfiles, pkg.CXXFiles, runcgo1...)
+	ofiles = append(ofiles, pkg.SysoFiles...)
 	ofile := filepath.Join(filepath.Dir(ofiles[0]), "_cgo_.o")
 	gcc2 := Action{
 		Name: "gccld: " + pkg.ImportPath + ": _cgo_.o",


### PR DESCRIPTION
this is based on: 
[golang/go/src/cmd/go/build.go#L1487-L1490](https://github.com/golang/go/blob/21efa7b2bc872958bcb252f5ab4dc52b2b0abeae/src/cmd/go/build.go#L1487-L1490)
[golang/go/src/cmd/go/build.go#L3056](https://github.com/golang/go/blob/21efa7b2bc872958bcb252f5ab4dc52b2b0abeae/src/cmd/go/build.go#L3056)

My use case was embedding the resource file inside cross compiled .exe without cgo
using: rsrc tool: [akavel/rsrc](https://github.com/akavel/rsrc)
or windres: lxn/walk#108
and it worked, I'm not sure how to write the test for this or if the cgo related changes are correct. 
Please advice, Thanks.