### PR TITLE
gb/cmd/gb: gb test now accepts -tags=a,b,c

### DIFF
--- a/cmd/gb/testflag.go
+++ b/cmd/gb/testflag.go
@@ -29,6 +29,7 @@ var testFlagDefn = map[string]*testFlagSpec{
 	"ldflags":   {},
 	"gcflags":   {},
 	"dotfile":   {},
+	"tags":      {},
 
 	// Passed to the test binary
 	"q":                {boolVar: true, passToTest: true},

--- a/cmd/gb/testflag_test.go
+++ b/cmd/gb/testflag_test.go
@@ -183,6 +183,9 @@ func TestTestFlags(t *testing.T) {
 		}, {
 			eargs: []string{"-test.short"},
 			targs: []string{"-test.short"},
+		}, {
+			eargs: []string{"-tags", "a,b,c"},
+			targs: []string{"-tags", "a,b,c"},
 		}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #423