### PR TITLE
cmd/gb: gb info reports GOROOT that build gb

### DIFF
--- a/cmd/gb/alldocs.go
+++ b/cmd/gb/alldocs.go
@@ -113,7 +113,20 @@ Usage:
 
         gb info
 
-info returns information about this project.
+info prints gb environment information.
+
+Values:
+
+	GB_PROJECT_DIR
+		The root of the gb project.
+	GB_SRC_PATH
+		The list of gb project source directories.
+	GB_PKG_DIR
+		The path of the gb project's package cache.
+	GB_BIN_SUFFIX
+		The suffix applied any binary written to $GB_PROJECT_DIR/bin
+	GB_GOROOT
+		The value of runtime.GOROOT for the Go version that built this copy of gb.
 
 info returns 0 if the project is well formed, and non zero otherwise.
 

--- a/cmd/gb/info.go
+++ b/cmd/gb/info.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/constabulary/gb"
@@ -28,6 +29,7 @@ func info(ctx *gb.Context, args []string) error {
 	fmt.Printf("GB_SRC_PATH=%q\n", joinlist(ctx.Srcdirs()...))
 	fmt.Printf("GB_PKG_DIR=%q\n", ctx.Pkgdir())
 	fmt.Printf("GB_BIN_SUFFIX=%q\n", ctx.Suffix())
+	fmt.Printf("GB_GOROOT=%q\n", runtime.GOROOT())
 	return nil
 }
 

--- a/cmd/gb/info.go
+++ b/cmd/gb/info.go
@@ -15,7 +15,21 @@ func init() {
 		Name:      "info",
 		UsageLine: `info`,
 		Short:     "info returns information about this project",
-		Long: `info returns information about this project.
+		Long: `
+info prints gb environment information.
+
+Values:
+
+	GB_PROJECT_DIR
+		The root of the gb project.
+	GB_SRC_PATH
+		The list of gb project source directories.
+	GB_PKG_DIR
+		The path of the gb project's package cache.
+	GB_BIN_SUFFIX
+		The suffix applied any binary written to $GB_PROJECT_DIR/bin
+	GB_GOROOT
+		The value of runtime.GOROOT for the Go version that built this copy of gb.
 
 info returns 0 if the project is well formed, and non zero otherwise.
 `,

--- a/cmd/gb/plugin.go
+++ b/cmd/gb/plugin.go
@@ -23,7 +23,7 @@ gb plugins are executed from the parent gb process with the environment
 variable, GB_PROJECT_DIR set to the root of the current project.
 
 gb plugins can be executed directly but this is rarely useful, so authors
-should attempt to diagnose this by looking for the presence of the 
+should attempt to diagnose this by looking for the presence of the
 GB_PROJECT_DIR environment key.
 `,
 }


### PR DESCRIPTION
Fixes #393
Fixes #394 

Add `GB_GOROOT` value to report the `GOROOT` that build this gb.