### PR TITLE
cmd/gb: gb test -v enables verbose test output

### DIFF
--- a/cmd/gb/alldocs.go
+++ b/cmd/gb/alldocs.go
@@ -194,14 +194,17 @@ Test packages
 
 Usage:
 
-        gb test [build flags] [packages] [flags for test binary]
+        gb test [build flags] -v [packages] [flags for test binary]
 
 Test automates testing the packages named by the import paths.
 
 'gb test' recompiles each package along with any files with names matching
 the file pattern "*_test.go".
 
-See 'go help test'.
+Flags:
+
+        -v
+                print output from test subprocess.
 
 
 */

--- a/cmd/gb/test.go
+++ b/cmd/gb/test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
+	"github.com/constabulary/gb/debug"
 	"github.com/constabulary/gb/test"
 )
 
@@ -21,6 +22,7 @@ var (
 	testCover     bool
 	testCoverMode string
 	testCoverPkg  string
+	testVerbose   bool // enable verbose output of test commands
 )
 
 func addTestFlags(fs *flag.FlagSet) {
@@ -28,11 +30,12 @@ func addTestFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&testCover, "cover", false, "enable coverage analysis")
 	fs.StringVar(&testCoverMode, "covermode", "set", "Set covermode: set (default), count, atomic")
 	fs.StringVar(&testCoverPkg, "coverpkg", "", "enable coverage analysis")
+	fs.BoolVar(&testVerbose, "v", false, "enable verbose output of subcommands")
 }
 
 var TestCmd = &cmd.Command{
 	Name:      "test",
-	UsageLine: "test [build flags] [packages] [flags for test binary]",
+	UsageLine: "test [build flags] -v [packages] [flags for test binary]",
 	Short:     "test packages",
 	Long: `
 Test automates testing the packages named by the import paths.
@@ -40,11 +43,15 @@ Test automates testing the packages named by the import paths.
 'gb test' recompiles each package along with any files with names matching
 the file pattern "*_test.go".
 
-See 'go help test'.
+Flags:
+
+        -v
+                print output from test subprocess.
 `,
 	Run: func(ctx *gb.Context, args []string) error {
 		ctx.Force = F
 		ctx.SkipInstall = FF
+		ctx.Verbose = testVerbose
 		r := test.TestResolver(ctx)
 
 		// gb build builds packages in dependency order, however
@@ -79,6 +86,7 @@ See 'go help test'.
 	FlagParse: func(flags *flag.FlagSet, args []string) error {
 		var err error
 		args, tfs, err = TestFlagsExtraParse(args[2:])
+		debug.Debugf("%s %s", args, tfs)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "gb test: %s\n", err)
 			fmt.Fprintf(os.Stderr, `run "go help test" or "go help testflag" for more information`+"\n")

--- a/cmd/gb/testflag.go
+++ b/cmd/gb/testflag.go
@@ -33,7 +33,7 @@ var testFlagDefn = map[string]*testFlagSpec{
 
 	// Passed to the test binary
 	"q":                {boolVar: true, passToTest: true},
-	"v":                {boolVar: true, passToTest: true},
+	"v":                {boolVar: true, passToAll: true},
 	"bench":            {passToTest: true},
 	"benchmem":         {boolVar: true, passToTest: true},
 	"benchtime":        {passToTest: true},

--- a/cmd/gb/testflag_test.go
+++ b/cmd/gb/testflag_test.go
@@ -18,7 +18,7 @@ func TestTestFlagsPreParse(t *testing.T) {
 			eargs: []string{"-q", "-test", "-debug"},
 		}, {
 			args:  []string{"-v", "-debug", "package_name"},
-			pargs: []string{"package_name"},
+			pargs: []string{"-v", "package_name"},
 			eargs: []string{"-v", "-debug"},
 		}, {
 			args:  []string{"-q", "-debug", "package_name"},

--- a/context.go
+++ b/context.go
@@ -33,6 +33,7 @@ type Context struct {
 
 	Force       bool // force rebuild of packages
 	SkipInstall bool // do not cache compiled packages
+	Verbose     bool // verbose output
 
 	pkgs map[string]*Package // map of package paths to resolved packages
 

--- a/test/test.go
+++ b/test/test.go
@@ -184,6 +184,7 @@ func TestPackage(targets map[string]*gb.Action, pkg *gb.Package, flags []string)
 				cmd.Dir = pkg.Dir // tests run in the original source directory
 				cmd.Stdout = &output
 				cmd.Stderr = &output
+				debug.Debugf("%s", cmd.Args)
 				err = cmd.Run() // run test
 
 				// test binaries can be very large, so always unlink the
@@ -196,9 +197,11 @@ func TestPackage(targets map[string]*gb.Action, pkg *gb.Package, flags []string)
 
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "# %s\n", pkg.ImportPath)
-				io.Copy(os.Stdout, &output)
 			} else {
 				fmt.Println(pkg.ImportPath)
+			}
+			if err != nil || pkg.Verbose {
+				io.Copy(os.Stdout, &output)
 			}
 			return err
 		},


### PR DESCRIPTION
Fixes #438