### PR TITLE
cmd/gb: info and env returns values for env vars

### DIFF
--- a/cmd/gb/alldocs.go
+++ b/cmd/gb/alldocs.go
@@ -88,9 +88,10 @@ Print project environment variables
 
 Usage:
 
-        gb env
+        gb env [var ...]
 
-Env prints project environment variables.
+Env prints project environment variables. If one or more variable names is 
+given as arguments, env prints the value of each named variable on its own line.
 
 
 Generate Go files by processing source
@@ -111,7 +112,7 @@ Info returns information about this project
 
 Usage:
 
-        gb info
+        gb info [var ...]
 
 info prints gb environment information.
 
@@ -129,6 +130,8 @@ Values:
 		The value of runtime.GOROOT for the Go version that built this copy of gb.
 
 info returns 0 if the project is well formed, and non zero otherwise.
+If one or more variable names is given as arguments, info prints the 
+value of each named variable on its own line.
 
 
 List the packages named by the importpaths

--- a/cmd/gb/env.go
+++ b/cmd/gb/env.go
@@ -19,6 +19,8 @@ given as arguments, env prints the value of each named variable on its own line.
 `,
 	Run: info,
 	ParseArgs: func(ctx *gb.Context, cwd string, args []string) []string {
+		// env treats arguments as environment variables names,
+		// don't do any processing.
 		return args
 	},
 }

--- a/cmd/gb/env.go
+++ b/cmd/gb/env.go
@@ -15,7 +15,7 @@ var EnvCmd = &cmd.Command{
 	Short:     "print project environment variables",
 	Long: `
 Env prints project environment variables. If one or more variable names is 
-given as arguments, info prints the value of each named variable on its own line.
+given as arguments, env prints the value of each named variable on its own line.
 `,
 	Run: info,
 	ParseArgs: func(ctx *gb.Context, cwd string, args []string) []string {

--- a/cmd/gb/env.go
+++ b/cmd/gb/env.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
 )
@@ -13,37 +11,14 @@ func init() {
 
 var EnvCmd = &cmd.Command{
 	Name:      "env",
-	UsageLine: `env`,
+	UsageLine: `env [var ...]`,
 	Short:     "print project environment variables",
 	Long: `
-Env prints project environment variables.
+Env prints project environment variables. If one or more variable names is 
+given as arguments, info prints the value of each named variable on its own line.
 `,
-	Run: env,
-}
-
-func env(ctx *gb.Context, args []string) error {
-	env := makeenv(ctx)
-	for _, e := range env {
-		fmt.Printf("%s=%q\n", e.name, e.val)
-	}
-	return nil
-}
-
-type envvar struct {
-	name, val string
-}
-
-func findenv(env []envvar, name string) string {
-	for _, e := range env {
-		if e.name == name {
-			return e.val
-		}
-	}
-	return ""
-}
-
-func makeenv(ctx *gb.Context) []envvar {
-	return []envvar{
-		{"GB_PROJECT_DIR", ctx.Projectdir()},
-	}
+	Run: info,
+	ParseArgs: func(ctx *gb.Context, cwd string, args []string) []string {
+		return args
+	},
 }

--- a/cmd/gb/gb_test.go
+++ b/cmd/gb/gb_test.go
@@ -595,9 +595,14 @@ func TestInfoWithArgs(t *testing.T) {
 
 	gb.tempDir("src")
 	gb.cd(gb.tempdir)
-	gb.run("info", "GB_PROJECT_DIR", "GB_GOROOT")
+	gb.run("info", "GB_PROJECT_DIR", "GB_MISSING", "GB_GOROOT")
 	gb.grepStdout(`^`+regexp.QuoteMeta(gb.tempdir), "missing "+regexp.QuoteMeta(gb.tempdir))
 	gb.grepStdout(`^`+regexp.QuoteMeta(runtime.GOROOT()), "missing "+regexp.QuoteMeta(runtime.GOROOT()))
+	// second line should be empty
+	lines := bytes.Split(gb.stdout.Bytes(), []byte{'\n'})
+	if len(lines[1]) != 0 {
+		t.Fatal("want 0, got", len(lines[1]))
+	}
 }
 
 // Only succeeds if source order is preserved.

--- a/cmd/gb/gb_test.go
+++ b/cmd/gb/gb_test.go
@@ -589,6 +589,17 @@ func TestInfoCmd(t *testing.T) {
 	gb.grepStdout(`^GB_GOROOT="`+regexp.QuoteMeta(runtime.GOROOT())+`"$`, "missing GB_GOROOT")
 }
 
+func TestInfoWithArgs(t *testing.T) {
+	gb := T{T: t}
+	defer gb.cleanup()
+
+	gb.tempDir("src")
+	gb.cd(gb.tempdir)
+	gb.run("info", "GB_PROJECT_DIR", "GB_GOROOT")
+	gb.grepStdout(`^`+regexp.QuoteMeta(gb.tempdir), "missing "+regexp.QuoteMeta(gb.tempdir))
+	gb.grepStdout(`^`+regexp.QuoteMeta(runtime.GOROOT()), "missing "+regexp.QuoteMeta(runtime.GOROOT()))
+}
+
 // Only succeeds if source order is preserved.
 func TestSourceFileNameOrderPreserved(t *testing.T) {
 	gb := T{T: t}

--- a/cmd/gb/info.go
+++ b/cmd/gb/info.go
@@ -37,6 +37,8 @@ value of each named variable on its own line.
 `,
 		Run: info,
 		ParseArgs: func(ctx *gb.Context, cwd string, args []string) []string {
+			// env treats arguments as environment variables names,
+			// don't do any processing.
 			return args
 		},
 		AddFlags: addBuildFlags,
@@ -45,12 +47,15 @@ value of each named variable on its own line.
 
 func info(ctx *gb.Context, args []string) error {
 	env := makeenv(ctx)
+	// print values for env variables when args are provided
 	if len(args) > 0 {
 		for _, arg := range args {
+			// print each var on its own line, blank line for each invalid variables
 			fmt.Println(findenv(env, arg))
 		}
 		return nil
 	}
+	// print all variable when no args are provided
 	for _, v := range env {
 		fmt.Printf("%s=\"%s\"\n", v.name, v.val)
 	}

--- a/cmd/gb/info.go
+++ b/cmd/gb/info.go
@@ -13,7 +13,7 @@ import (
 func init() {
 	registerCommand(&cmd.Command{
 		Name:      "info",
-		UsageLine: `info`,
+		UsageLine: `info [var ...]`,
 		Short:     "info returns information about this project",
 		Long: `
 info prints gb environment information.
@@ -32,22 +32,27 @@ Values:
 		The value of runtime.GOROOT for the Go version that built this copy of gb.
 
 info returns 0 if the project is well formed, and non zero otherwise.
+If one or more variable names is given as arguments, info prints the 
+value of each named variable on its own line.
 `,
-		Run:      info,
+		Run: info,
+		ParseArgs: func(ctx *gb.Context, cwd string, args []string) []string {
+			return args
+		},
 		AddFlags: addBuildFlags,
 	})
 }
 
 func info(ctx *gb.Context, args []string) error {
-	vars := []struct{ name, value string }{
-		{"GB_PROJECT_DIR", ctx.Projectdir()},
-		{"GB_SRC_PATH", joinlist(ctx.Srcdirs()...)},
-		{"GB_PKG_DIR", ctx.Pkgdir()},
-		{"GB_BIN_SUFFIX", ctx.Suffix()},
-		{"GB_GOROOT", runtime.GOROOT()},
+	env := makeenv(ctx)
+	if len(args) > 0 {
+		for _, arg := range args {
+			fmt.Println(findenv(env, arg))
+		}
+		return nil
 	}
-	for _, v := range vars {
-		fmt.Printf("%s=\"%s\"\n", v.name, v.value)
+	for _, v := range env {
+		fmt.Printf("%s=\"%s\"\n", v.name, v.val)
 	}
 	return nil
 }
@@ -56,4 +61,27 @@ func info(ctx *gb.Context, args []string) error {
 // TODO(dfc) it probably gets this wrong on windows in some circumstances.
 func joinlist(paths ...string) string {
 	return strings.Join(paths, string(filepath.ListSeparator))
+}
+
+type envvar struct {
+	name, val string
+}
+
+func findenv(env []envvar, name string) string {
+	for _, e := range env {
+		if e.name == name {
+			return e.val
+		}
+	}
+	return ""
+}
+
+func makeenv(ctx *gb.Context) []envvar {
+	return []envvar{
+		{"GB_PROJECT_DIR", ctx.Projectdir()},
+		{"GB_SRC_PATH", joinlist(ctx.Srcdirs()...)},
+		{"GB_PKG_DIR", ctx.Pkgdir()},
+		{"GB_BIN_SUFFIX", ctx.Suffix()},
+		{"GB_GOROOT", runtime.GOROOT()},
+	}
 }


### PR DESCRIPTION
`gb info` optionally accepts a list of environment variable names and
returns their values. `gb env` is aliased to gb info.

Updates #476