### PR TITLE
manifest: ensure nul termination

### DIFF
--- a/vendor/manifest.go
+++ b/vendor/manifest.go
@@ -117,6 +117,8 @@ func writeManifest(w io.Writer, m *Manifest) error {
 	if err != nil {
 		return err
 	}
+	buf = append(buf, 0)
+
 	_, err = io.Copy(w, bytes.NewReader(buf))
 	return err
 }


### PR DESCRIPTION
Prevents creating a diff when opening the file in an editor and compulsively writing before exiting...