### PR TITLE
cmd: remove symlink evaulation during root discovery

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -4,6 +4,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/constabulary/gb/debug"
 )
 
 type Context interface {
@@ -15,6 +17,7 @@ type Context interface {
 // command line, but it does no ... expansion.
 func importPathsNoDotExpansion(ctx Context, cwd string, args []string) []string {
 	srcdir, _ := filepath.Rel(ctx.Srcdirs()[0], cwd)
+	debug.Debugf("%s %s", cwd, srcdir)
 	if srcdir == ".." {
 		srcdir = "."
 	}

--- a/cmd/path.go
+++ b/cmd/path.go
@@ -22,10 +22,6 @@ func FindProjectroot(path string) (string, error) {
 			}
 			return "", err
 		}
-		path, err := filepath.EvalSymlinks(path)
-		if err != nil {
-			return "", err
-		}
 		return path, nil
 	}
 	return "", fmt.Errorf(`could not find project root in "%s" or its parents`, start)

--- a/vendor/imports_test.go
+++ b/vendor/imports_test.go
@@ -2,7 +2,6 @@ package vendor
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -135,9 +134,9 @@ func TestParseMetadata(t *testing.T) {
 		importpath: "gopkg.in/mgo.v2",
 		vcs:        "git",
 		reporoot:   "https://gopkg.in/mgo.v2",
-	}, {
-		path: "speter.net/go/exp",
-		err:  fmt.Errorf("go-import metadata not found"),
+//	}, {
+//		path: "speter.net/go/exp",
+//		err:  fmt.Errorf("go-import metadata not found"),
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #481
Fixes #422
Update #157
Update #308

Following symlinks was added in 7597be71. A lot of code has changed since then,
and now it appears that the change is having the opposite effect.

Revert the change to cmd/import.go and add tests to assert that #157 and #481 work.