### PR TITLE
cmd: remove Command.ParseArgs

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -36,10 +36,8 @@ type Command struct {
 	// Allow plugins to modify arguments
 	FlagParse func(fs *flag.FlagSet, args []string) error
 
-	// ParseArgs provides an alternative method to parse arguments.
-	// By default, arguments will be parsed as import paths with
-	// ImportPaths
-	ParseArgs func(ctx *gb.Context, cwd string, args []string) []string
+	// SkipParseArgs avoids parsing arguments as import paths.
+	SkipParseArgs bool
 }
 
 // Runnable indicates this is a command that can be involved.

--- a/cmd/gb/doc.go
+++ b/cmd/gb/doc.go
@@ -40,6 +40,6 @@ See 'go help doc'.
 			}
 			return cmd.Run()
 		},
-		ParseArgs: func(_ *gb.Context, _ string, args []string) []string { return args },
+		SkipParseArgs: true,
 	})
 }

--- a/cmd/gb/env.go
+++ b/cmd/gb/env.go
@@ -1,9 +1,6 @@
 package main
 
-import (
-	"github.com/constabulary/gb"
-	"github.com/constabulary/gb/cmd"
-)
+import "github.com/constabulary/gb/cmd"
 
 func init() {
 	registerCommand(EnvCmd)
@@ -17,10 +14,6 @@ var EnvCmd = &cmd.Command{
 Env prints project environment variables. If one or more variable names is 
 given as arguments, env prints the value of each named variable on its own line.
 `,
-	Run: info,
-	ParseArgs: func(ctx *gb.Context, cwd string, args []string) []string {
-		// env treats arguments as environment variables names,
-		// don't do any processing.
-		return args
-	},
+	Run:           info,
+	SkipParseArgs: true,
 }

--- a/cmd/gb/info.go
+++ b/cmd/gb/info.go
@@ -35,13 +35,9 @@ info returns 0 if the project is well formed, and non zero otherwise.
 If one or more variable names is given as arguments, info prints the 
 value of each named variable on its own line.
 `,
-		Run: info,
-		ParseArgs: func(ctx *gb.Context, cwd string, args []string) []string {
-			// env treats arguments as environment variables names,
-			// don't do any processing.
-			return args
-		},
-		AddFlags: addBuildFlags,
+		Run:           info,
+		SkipParseArgs: true,
+		AddFlags:      addBuildFlags,
 	})
 }
 

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -91,7 +91,7 @@ func main() {
 				return cmd.Run()
 			},
 			// plugin should not interpret arguments
-			ParseArgs: func(_ *gb.Context, _ string, args []string) []string { return args },
+			SkipParseArgs: true,
 		}
 	}
 
@@ -130,9 +130,7 @@ func main() {
 		fatalf("unable to construct context: %v", err)
 	}
 
-	if command.ParseArgs != nil {
-		args = command.ParseArgs(ctx, ctx.Projectdir(), args)
-	} else {
+	if !command.SkipParseArgs {
 		args = cmd.ImportPaths(ctx, cwd, args)
 	}
 

--- a/vendor/imports_test.go
+++ b/vendor/imports_test.go
@@ -134,9 +134,9 @@ func TestParseMetadata(t *testing.T) {
 		importpath: "gopkg.in/mgo.v2",
 		vcs:        "git",
 		reporoot:   "https://gopkg.in/mgo.v2",
-//	}, {
-//		path: "speter.net/go/exp",
-//		err:  fmt.Errorf("go-import metadata not found"),
+		//	}, {
+		//		path: "speter.net/go/exp",
+		//		err:  fmt.Errorf("go-import metadata not found"),
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
ParseArgs required a context before it could be called, but it was
never used. In all cases ParseArgs was being used to skip treating
arguments as packages (or package globs).