### PR TITLE
Fix `gb vendor fetch goji.io`

### DIFF
--- a/vendor/repo.go
+++ b/vendor/repo.go
@@ -69,7 +69,7 @@ func DeduceRemoteRepo(path string, insecure bool) (RemoteRepo, string, error) {
 	}
 
 	path = u.Host + u.Path
-	if !regexp.MustCompile(`^([A-Za-z0-9-]+)(.[A-Za-z0-9-]+)+(/[A-Za-z0-9-_.]+)*$`).MatchString(path) {
+	if !regexp.MustCompile(`^([A-Za-z0-9-]+)(\.[A-Za-z0-9-]+)+(/[A-Za-z0-9-_.]+)*$`).MatchString(path) {
 		return nil, "", fmt.Errorf("%q is not a valid import path", path)
 	}
 

--- a/vendor/repo.go
+++ b/vendor/repo.go
@@ -69,7 +69,7 @@ func DeduceRemoteRepo(path string, insecure bool) (RemoteRepo, string, error) {
 	}
 
 	path = u.Host + u.Path
-	if !regexp.MustCompile(`^([A-Za-z0-9-]+)(.[A-Za-z0-9-]+)+(/[A-Za-z0-9-_.]+)+$`).MatchString(path) {
+	if !regexp.MustCompile(`^([A-Za-z0-9-]+)(.[A-Za-z0-9-]+)+(/[A-Za-z0-9-_.]+)*$`).MatchString(path) {
 		return nil, "", fmt.Errorf("%q is not a valid import path", path)
 	}
 

--- a/vendor/repo_test.go
+++ b/vendor/repo_test.go
@@ -84,6 +84,12 @@ func TestDeduceRemoteRepo(t *testing.T) {
 		},
 		extra: "",
 	}, {
+		path: "goji.io",
+		want: &gitrepo{
+			url: "https://github.com/goji/goji",
+		},
+		extra: "",
+	}, {
 		path: "golang.org/x/tools/go/vcs",
 		want: &gitrepo{
 			url: "https://go.googlesource.com/tools",


### PR DESCRIPTION
Prior to this PR, attempting to run `gb vendor fetch goji.io` would error out with a "not a valid import path" error.  This was unexpected since `go get goji.io` works fine.