### PR TITLE
Add race detector support

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -146,6 +146,7 @@ func TestBuildPackages(t *testing.T) {
 	tests := []struct {
 		pkgs    []string
 		actions []string
+		options []func(*Context) error // set of options to apply to the test context
 		err     error
 	}{{
 		pkgs:    []string{"a", "b", "c"},
@@ -153,10 +154,14 @@ func TestBuildPackages(t *testing.T) {
 	}, {
 		pkgs:    []string{"cgotest", "cgomain", "notestfiles", "cgoonlynotest", "testonly", "extestonly"},
 		actions: []string{"compile: notestfiles", "link: cgomain", "pack: cgoonlynotest", "pack: cgotest"},
+	}, {
+		pkgs:    []string{"a", "b", "c"},
+		options: []func(*Context) error{WithRace},
+		actions: []string{"compile: a", "compile: c", "link: b"},
 	}}
 
 	for _, tt := range tests {
-		ctx := testContext(t)
+		ctx := testContext(t, tt.options...)
 		defer ctx.Destroy()
 		var pkgs []*Package
 		for _, pkg := range tt.pkgs {

--- a/cmd/gb/gb_test.go
+++ b/cmd/gb/gb_test.go
@@ -1293,5 +1293,4 @@ func TestRaceMapRW(t *testing.T) {
 	gb.setenv("TMP", tmpdir)
 	gb.runFail("test", "-race")
 	gb.mustBeEmpty(tmpdir)
-	gb.mustNotExist(filepath.Join(gb.tempdir, "pkg")) // ensure no pkg directory is created
 }

--- a/context.go
+++ b/context.go
@@ -324,6 +324,13 @@ func (c *Context) shouldignore(p string) bool {
 	if c.isCrossCompile() {
 		return p == "C" || p == "unsafe"
 	}
+
+	// Always consider standard library in scope if race enabled.
+	// This may mean that a race runtime is built into the project's
+	// cache. Issue #490.
+	if false && c.race {
+		return p == "C" || p == "unsafe"
+	}
 	return stdlib[p]
 }
 

--- a/context.go
+++ b/context.go
@@ -76,11 +76,30 @@ func Tags(tags ...string) func(*Context) error {
 	}
 }
 
+// Gcflags appends flags to the list passed to the compiler.
+func Gcflags(flags ...string) func(*Context) error {
+	return func(c *Context) error {
+		c.gcflags = append(c.gcflags, flags...)
+		return nil
+	}
+}
+
+// Ldflags appends flags to the list passed to the linker.
+func Ldflags(flags ...string) func(*Context) error {
+	return func(c *Context) error {
+		c.ldflags = append(c.ldflags, flags...)
+		return nil
+	}
+}
+
 // WithRace enables the race detector and adds the tag "race" to
 // the Context build tags.
 func WithRace(c *Context) error {
 	c.race = true
-	return Tags("race")(c)
+	Tags("race")(c)
+	Gcflags("-race")(c)
+	Ldflags("-race")(c)
+	return nil
 }
 
 // NewContext returns a new build context from this project.
@@ -147,22 +166,6 @@ func (p *Project) NewContext(opts ...func(*Context) error) (*Context, error) {
 	}
 
 	return &ctx, nil
-}
-
-// Gcflags sets options passed to the compiler.
-func Gcflags(flags ...string) func(*Context) error {
-	return func(c *Context) error {
-		c.gcflags = flags
-		return nil
-	}
-}
-
-// Ldflags sets options passed to the linker.
-func Ldflags(flags ...string) func(*Context) error {
-	return func(c *Context) error {
-		c.ldflags = flags
-		return nil
-	}
 }
 
 // IncludePaths returns the include paths visible in this context.

--- a/context_test.go
+++ b/context_test.go
@@ -123,10 +123,26 @@ func TestContextOptions(t *testing.T) {
 		fn:     Tags("bar"),
 		expect: matches(Context{buildtags: []string{"foo", "bar"}}),
 	}, {
+		fn:     Gcflags("foo"),
+		expect: matches(Context{gcflags: []string{"foo"}}),
+	}, {
+		ctx:    Context{gcflags: []string{"foo"}},
+		fn:     Gcflags("bar"),
+		expect: matches(Context{gcflags: []string{"foo", "bar"}}),
+	}, {
+		fn:     Ldflags("foo"),
+		expect: matches(Context{ldflags: []string{"foo"}}),
+	}, {
+		ctx:    Context{ldflags: []string{"foo"}},
+		fn:     Ldflags("bar"),
+		expect: matches(Context{ldflags: []string{"foo", "bar"}}),
+	}, {
 		fn: WithRace,
 		expect: matches(Context{
 			buildtags: []string{"race"},
 			race:      true,
+			gcflags:   []string{"-race"},
+			ldflags:   []string{"-race"},
 		}),
 	}, {
 		ctx: Context{buildtags: []string{"zzz"}},
@@ -134,6 +150,8 @@ func TestContextOptions(t *testing.T) {
 		expect: matches(Context{
 			buildtags: []string{"zzz", "race"},
 			race:      true,
+			gcflags:   []string{"-race"},
+			ldflags:   []string{"-race"},
 		}),
 	}}
 

--- a/package_test.go
+++ b/package_test.go
@@ -16,9 +16,9 @@ func testProject(t *testing.T) *Project {
 	)
 }
 
-func testContext(t *testing.T) *Context {
+func testContext(t *testing.T, opts ...func(*Context) error) *Context {
 	prj := testProject(t)
-	ctx, err := prj.NewContext()
+	ctx, err := prj.NewContext(opts...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stdlib.go
+++ b/stdlib.go
@@ -115,6 +115,7 @@ var stdlib = map[string]bool{
 	"regexp/syntax":       true,
 	"runtime":             true,
 	"runtime/cgo":         true,
+	"runtime/race":        true,
 	"runtime/debug":       true,
 	"runtime/pprof":       true,
 	"sort":                true,


### PR DESCRIPTION
Fixes #96

Adds the race detector you all know and love to gb.

Todo:
- [ ] Add support for rebuilding stdlib if -race support is not present.
- [ ] Add interlocks to restrict the race detector to certain amd64 for freebsd, linux, darwin, and linux.
- [ ] Make all binaries dependant on runtime/race.
- [x] Add tests to cmd/gb
- [ ] Add gb and gb/test tests