### PR TITLE
Refactor goversion support

### DIFF
--- a/cgo.go
+++ b/cgo.go
@@ -14,9 +14,9 @@ import (
 
 func cgo(pkg *Package) (*Action, []string, []string, error) {
 	switch {
-	case gc14:
+	case goversion == 1.4:
 		return cgo14(pkg)
-	case gc15:
+	case goversion > 1.4:
 		return cgo15(pkg)
 	default:
 		return nil, nil, nil, fmt.Errorf("unsupported Go version: %v", runtime.Version)
@@ -387,12 +387,12 @@ func runcgo1(pkg *Package, cflags, ldflags []string) error {
 
 	args := []string{"-objdir", workdir}
 	switch {
-	case gc14:
+	case goversion == 1.4:
 		args = append(args,
 			"--",
 			"-I", pkg.Dir,
 		)
-	case gc15:
+	case goversion > 1.4:
 		args = append(args,
 			"-importpath", pkg.ImportPath,
 			"--",
@@ -427,12 +427,12 @@ func runcgo2(pkg *Package, dynout, ofile string) error {
 		"-objdir", workdir,
 	}
 	switch {
-	case gc14:
+	case goversion == 1.4:
 		args = append(args,
 			"-dynimport", ofile,
 			"-dynout", dynout,
 		)
-	case gc15:
+	case goversion > 1.4:
 		args = append(args,
 			"-dynpackage", pkg.Name,
 			"-dynimport", ofile,

--- a/gb14.go
+++ b/gb14.go
@@ -1,8 +1,0 @@
-// +build !go1.5
-
-package gb
-
-const (
-	gc14 = true
-	gc15 = false
-)

--- a/gb15.go
+++ b/gb15.go
@@ -1,8 +1,0 @@
-// +build go1.5
-
-package gb
-
-const (
-	gc14 = false
-	gc15 = true
-)

--- a/goversion12.go
+++ b/goversion12.go
@@ -1,0 +1,6 @@
+// +build go1.2
+// +build !go1.3,!go1.4,!go1.5,!go1.6
+
+package gb
+
+const goversion = 1.2

--- a/goversion13.go
+++ b/goversion13.go
@@ -1,0 +1,6 @@
+// +build go1.3
+// +build !go1.4,!go1.5,!go1.6
+
+package gb
+
+const goversion = 1.3

--- a/goversion14.go
+++ b/goversion14.go
@@ -1,0 +1,6 @@
+// +build go1.4
+// +build !go1.5,!go1.6
+
+package gb
+
+const goversion = 1.4

--- a/goversion15.go
+++ b/goversion15.go
@@ -1,0 +1,6 @@
+// +build go1.5
+// +build !go1.6
+
+package gb
+
+const goversion = 1.5

--- a/goversion16.go
+++ b/goversion16.go
@@ -1,0 +1,5 @@
+// +build go1.6
+
+package gb
+
+const goversion = 1.6


### PR DESCRIPTION
Previously we had two constants, go14 and go15, but adding a third, go16 makes
it clear that the design is wrong.

Replace this with one constant, `goversion` which can be compared with other
constants literals at compile time. eg, `if goversion > 1.4 { // go 1.5 and later }`.