### PR TITLE
Introduce installpath

### DIFF
--- a/build.go
+++ b/build.go
@@ -195,7 +195,7 @@ func Compile(pkg *Package, deps ...*Action) (*Action, error) {
 		build = &Action{
 			Name: fmt.Sprintf("install: %s", pkg.ImportPath),
 			Deps: []*Action{build},
-			Run:  func() error { return fileutils.Copyfile(pkgfile(pkg), objfile(pkg)) },
+			Run:  func() error { return fileutils.Copyfile(installpath(pkg), objfile(pkg)) },
 		}
 	}
 

--- a/install.go
+++ b/install.go
@@ -6,16 +6,25 @@ import (
 	"time"
 )
 
-// pkgdir returns the destination for object cached for this Package.
-func pkgdir(pkg *Package) string {
-	if pkg.Scope == "test" {
-		panic("pkgdir called with test scope")
-	}
-	return filepath.Join(pkg.Pkgdir(), filepath.Dir(filepath.FromSlash(pkg.ImportPath)))
+// pkgfile returns the destination for object cached for this Package.
+func pkgfile(pkg *Package) string {
+	return filepath.Join(pkg.Pkgdir(), filepath.FromSlash(pkg.ImportPath)+".a")
 }
 
-func pkgfile(pkg *Package) string {
-	return filepath.Join(pkgdir(pkg), filepath.Base(filepath.FromSlash(pkg.ImportPath))+".a")
+// installpath returns the distination to cache this package's compiled .a file.
+// pkgfile and installpath differ in that the former returns the location where you will find
+// a previously cached .a file, the latter returns the location where an installed file
+// will be placed.
+//
+// The difference is subtle. pkgfile must deal with the possibility that the file is from the
+// standard library and is previously compiled. installpath will always return a path for the
+// project's pkg/ directory in the case that the stdlib is out of date, or not compiled for
+// a specific architecture.
+func installpath(pkg *Package) string {
+	if pkg.Scope == "test" {
+		panic("installpath called with test scope")
+	}
+	return filepath.Join(pkg.Pkgdir(), filepath.FromSlash(pkg.ImportPath)+".a")
 }
 
 // isStale returns true if the source pkg is considered to be stale with

--- a/install_test.go
+++ b/install_test.go
@@ -78,3 +78,38 @@ func TestStale(t *testing.T) {
 		}
 	}
 }
+
+func TestInstallpath(t *testing.T) {
+	ctx := testContext(t)
+	defer ctx.Destroy()
+
+	tests := []struct {
+		pkg         string
+		installpath string
+	}{{
+		pkg:         "a", // from testdata
+		installpath: filepath.Join(ctx.Pkgdir(), "a.a"),
+	}, {
+		pkg:         "runtime", // from stdlib
+		installpath: filepath.Join(ctx.Pkgdir(), "runtime.a"),
+	}, {
+		pkg:         "unsafe", // synthetic
+		installpath: filepath.Join(ctx.Pkgdir(), "unsafe.a"),
+	}}
+
+	resolve := func(pkg string) *Package {
+		p, err := ctx.ResolvePackage(pkg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	for _, tt := range tests {
+		pkg := resolve(tt.pkg)
+		got := installpath(pkg)
+		if got != tt.installpath {
+			t.Errorf("installpath(%q): expected: %v, got %v", tt.pkg, tt.installpath, got)
+		}
+	}
+}


### PR DESCRIPTION
`installpath` always returns the path to install a `.a` file into `$PROJECT/pkg/$tag`.
We also remove `pkgdir`, and roll it into `pkgfile` as there is now only one caller.

A future PR will refactor `pkgfile` to return the location of a previously
compiled `.a` file.