### PR TITLE
Refactor pkgfile to become pkgpath

### DIFF
--- a/install.go
+++ b/install.go
@@ -3,20 +3,33 @@ package gb
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
+
+	"github.com/constabulary/gb/debug"
 )
 
-// pkgfile returns the destination for object cached for this Package.
-func pkgfile(pkg *Package) string {
-	return filepath.Join(pkg.Pkgdir(), filepath.FromSlash(pkg.ImportPath)+".a")
+// pkgpath returns the destination for object cached for this Package.
+func pkgpath(pkg *Package) string {
+	importpath := filepath.FromSlash(pkg.ImportPath) + ".a"
+	switch {
+	case pkg.Standard && pkg.race:
+		// race enabled standard lib
+		return filepath.Join(runtime.GOROOT(), "pkg", pkg.gotargetos+"_"+pkg.gotargetarch+"_race", importpath)
+	case pkg.Standard:
+		// standard lib
+		return filepath.Join(runtime.GOROOT(), "pkg", pkg.gotargetos+"_"+pkg.gotargetarch, importpath)
+	default:
+		return filepath.Join(pkg.Pkgdir(), importpath)
+	}
 }
 
 // installpath returns the distination to cache this package's compiled .a file.
-// pkgfile and installpath differ in that the former returns the location where you will find
+// pkgpath and installpath differ in that the former returns the location where you will find
 // a previously cached .a file, the latter returns the location where an installed file
 // will be placed.
 //
-// The difference is subtle. pkgfile must deal with the possibility that the file is from the
+// The difference is subtle. pkgpath must deal with the possibility that the file is from the
 // standard library and is previously compiled. installpath will always return a path for the
 // project's pkg/ directory in the case that the stdlib is out of date, or not compiled for
 // a specific architecture.
@@ -30,7 +43,13 @@ func installpath(pkg *Package) string {
 // isStale returns true if the source pkg is considered to be stale with
 // respect to its installed version.
 func isStale(pkg *Package) bool {
-	if pkg.Force {
+	switch pkg.ImportPath {
+	case "C", "unsafe":
+		// synthetic packages are never stale
+		return false
+	}
+
+	if !pkg.Standard && pkg.Force {
 		return true
 	}
 
@@ -41,11 +60,12 @@ func isStale(pkg *Package) bool {
 
 	// Package is stale if completely unbuilt.
 	var built time.Time
-	if fi, err := os.Stat(pkgfile(pkg)); err == nil {
+	if fi, err := os.Stat(pkgpath(pkg)); err == nil {
 		built = fi.ModTime()
 	}
 
 	if built.IsZero() {
+		debug.Debugf("%s is missing", pkgpath(pkg))
 		return true
 	}
 
@@ -65,16 +85,24 @@ func isStale(pkg *Package) bool {
 	// the linker.  This heuristic will not work if the binaries are
 	// back-dated, as some binary distributions may do, but it does handle
 	// a very common case.
-	if olderThan(pkg.tc.compiler()) {
-		return true
-	}
-	if pkg.IsCommand() && olderThan(pkg.tc.linker()) {
-		return true
+	if !pkg.Standard {
+		if olderThan(pkg.tc.compiler()) {
+			debug.Debugf("%s is older than %s", pkgpath(pkg), pkg.tc.compiler())
+			return true
+		}
+		if pkg.IsCommand() && olderThan(pkg.tc.linker()) {
+			debug.Debugf("%s is older than %s", pkgpath(pkg), pkg.tc.compiler())
+			return true
+		}
 	}
 
 	// Package is stale if a dependency is newer.
 	for _, p := range pkg.Imports() {
-		if olderThan(pkgfile(p)) {
+		if p.ImportPath == "C" || p.ImportPath == "unsafe" {
+			continue // ignore stale imports of synthetic packages
+		}
+		if olderThan(pkgpath(p)) {
+			debug.Debugf("%s is older than %s", pkgpath(pkg), pkgpath(p))
 			return true
 		}
 	}
@@ -82,6 +110,7 @@ func isStale(pkg *Package) bool {
 	// if the main package is up to date but _newer_ than the binary (which
 	// could have been removed), then consider it stale.
 	if pkg.isMain() && newerThan(pkg.Binfile()) {
+		debug.Debugf("%s is newer than %s", pkgpath(pkg), pkg.Binfile())
 		return true
 	}
 
@@ -89,6 +118,7 @@ func isStale(pkg *Package) bool {
 
 	for _, src := range srcs {
 		if olderThan(filepath.Join(pkg.Dir, src)) {
+			debug.Debugf("%s is older than %s", pkgpath(pkg), filepath.Join(pkg.Dir, src))
 			return true
 		}
 	}


### PR DESCRIPTION
`pkgpath` always returns the location where a previously compiled `.a` for this
package would be found. `pkgpath` considers elements of the context like tags
cross compilation and race status.

`pkgpath` is used exclusively by `isStale` to determine if the package is up to date.
However, `pkgpath` is _not_ used to compute the target to install a `.a` file. This
discontinuity takes into account the fact that if the stdlib is missing for a
particular build context, replacement files should be written to `installpath`,
the `$PROJECT/pkg/` directory.