### PR TITLE
fix for #506, adding extld back into Ld()

### DIFF
--- a/cgo.go
+++ b/cgo.go
@@ -510,6 +510,14 @@ func ccompilerCmd(pkg *Package, envvar, defcmd, objdir string) []string {
 	return a
 }
 
+// linkCmd returns the name of the binary to use for linking for the given
+// environment variable and using the default command when the variable is
+// empty.
+func linkCmd(pkg *Package, envvar, defcmd string) string {
+	compiler := envList(envvar, defcmd)
+	return compiler[0]
+}
+
 // gccArchArgs returns arguments to pass to gcc based on the architecture.
 func gccArchArgs(goarch string) []string {
 	switch goarch {

--- a/gc.go
+++ b/gc.go
@@ -99,6 +99,7 @@ func (t *gcToolchain) Ld(pkg *Package, searchpaths []string, outfile, afile stri
 	for _, d := range searchpaths {
 		args = append(args, "-L", d)
 	}
+	args = append(args, "-extld", linkCmd(pkg, "CC", defaultCC))
 	if goversion > 1.4 {
 		args = append(args, "-buildmode", pkg.buildmode)
 	}


### PR DESCRIPTION
Hiya,

This fix works for me under the above conditions.  Not sure if this introduces regressions in other environments, but I feel "It Should Work".

The extld was removed via commit de34371c9f25bef9e9b6fdb45d653022738ef6fd, not sure why, probably gcc() disappeared?

Derek