### PR TITLE
remove use of context.GOROOT

### DIFF
--- a/cgo.go
+++ b/cgo.go
@@ -312,8 +312,7 @@ func libgcc(ctx *Context) (string, error) {
 }
 
 func cgotool(ctx *Context) string {
-	// TODO(dfc) need ctx.GOROOT method
-	return filepath.Join(ctx.Context.GOROOT, "pkg", "tool", ctx.gohostos+"_"+ctx.gohostarch, "cgo")
+	return filepath.Join(runtime.GOROOT(), "pkg", "tool", ctx.gohostos+"_"+ctx.gohostarch, "cgo")
 }
 
 // envList returns the value of the given environment variable broken

--- a/cmd/gb/doc.go
+++ b/cmd/gb/doc.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
@@ -27,7 +28,7 @@ See 'go help doc'.
 			if len(args) == 0 {
 				args = append(args, ".")
 			}
-			args = append([]string{filepath.Join(ctx.Context.GOROOT, "bin", "godoc")}, args...)
+			args = append([]string{filepath.Join(runtime.GOROOT(), "bin", "godoc")}, args...)
 
 			cmd := exec.Cmd{
 				Path: args[0],

--- a/cmd/gb/generate.go
+++ b/cmd/gb/generate.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
@@ -31,7 +32,7 @@ See 'go help generate'.
 			"GOPATH": fmt.Sprintf("%s:%s", ctx.Projectdir(), filepath.Join(ctx.Projectdir(), "vendor")),
 		})
 
-		args = append([]string{filepath.Join(ctx.Context.GOROOT, "bin", "go"), "generate"}, args...)
+		args = append([]string{filepath.Join(runtime.GOROOT(), "bin", "go"), "generate"}, args...)
 
 		cmd := exec.Cmd{
 			Path: args[0],

--- a/gc.go
+++ b/gc.go
@@ -64,7 +64,7 @@ func (t *gcToolchain) Asm(pkg *Package, srcdir, ofile, sfile string) error {
 	args := []string{"-o", ofile, "-D", "GOOS_" + pkg.gotargetos, "-D", "GOARCH_" + pkg.gotargetarch}
 	switch {
 	case goversion == 1.4:
-		includedir := filepath.Join(pkg.Context.Context.GOROOT, "pkg", pkg.gotargetos+"_"+pkg.gotargetarch)
+		includedir := filepath.Join(runtime.GOROOT(), "pkg", pkg.gotargetos+"_"+pkg.gotargetarch)
 		args = append(args, "-I", includedir)
 	case goversion > 1.4:
 		odir := filepath.Join(filepath.Dir(ofile))
@@ -128,7 +128,7 @@ func (t *gcToolchain) Cc(pkg *Package, ofile, cfile string) error {
 		"-F", "-V", "-w",
 		"-trimpath", pkg.Workdir(),
 		"-I", Workdir(pkg),
-		"-I", filepath.Join(pkg.Context.Context.GOROOT, "pkg", pkg.gohostos+"_"+pkg.gohostarch), // for runtime.h
+		"-I", filepath.Join(runtime.GOROOT(), "pkg", pkg.gohostos+"_"+pkg.gohostarch), // for runtime.h
 		"-o", ofile,
 		"-D", "GOOS_" + pkg.gotargetos,
 		"-D", "GOARCH_" + pkg.gotargetarch,

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -184,7 +185,7 @@ func TestTestPackages(t *testing.T) {
 		sort.Strings(actual)
 		var expected []string
 		exe := ""
-		if ctx.Context.GOOS == "windows" {
+		if runtime.GOOS == "windows" {
 			exe = ".exe"
 		}
 		for _, s := range tt.actions {


### PR DESCRIPTION
gb.Context.Context is going away, it will be replaced by a rewritten
importer package. This PR is an intermediary step which simplifies the
interface to build.Context.Import.