### PR TITLE
Remove build context

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -166,3 +166,26 @@ func TestContextOptions(t *testing.T) {
 		}
 	}
 }
+
+func TestContextLoadPackage(t *testing.T) {
+	tests := []struct {
+		opts []func(*Context) error
+		path string
+	}{
+		{path: "errors"},
+		{path: "net/http"}, // triggers vendor logic on go 1.6+
+	}
+
+	proj := testProject(t)
+	for _, tt := range tests {
+		ctx, err := proj.NewContext(tt.opts...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ctx.Destroy()
+		_, err = ctx.loadPackage(nil, tt.path)
+		if err != nil {
+			t.Errorf("loadPackage(%q): %v", tt.path, err)
+		}
+	}
+}

--- a/install.go
+++ b/install.go
@@ -118,7 +118,7 @@ func isStale(pkg *Package) bool {
 
 	if pkg.Standard && !pkg.isCrossCompile() {
 		// if this is a standard lib package, and we are not cross compiling
-		// then assume the package is up to date. This also works around 
+		// then assume the package is up to date. This also works around
 		// golang/go#13769.
 		return false
 	}


### PR DESCRIPTION
Remove `Context.Context`, in preparation for the new importer.