### PR TITLE
Always assume the stdlib is up to date if present

### DIFF
--- a/install.go
+++ b/install.go
@@ -116,6 +116,13 @@ func isStale(pkg *Package) bool {
 		return true
 	}
 
+	if pkg.Standard && !pkg.isCrossCompile() {
+		// if this is a standard lib package, and we are not cross compiling
+		// then assume the package is up to date. This also works around 
+		// golang/go#13769.
+		return false
+	}
+
 	srcs := stringList(pkg.GoFiles, pkg.CFiles, pkg.CXXFiles, pkg.MFiles, pkg.HFiles, pkg.SFiles, pkg.CgoFiles, pkg.SysoFiles, pkg.SwigFiles, pkg.SwigCXXFiles)
 
 	for _, src := range srcs {


### PR DESCRIPTION
Fixes #515

In the 0.3.x series we removed the hard coded list of packages to assume
are up to date and let that fall through to `isStale`. This worked ok, except
the Go installer for Darwin is broken and its timestamps are not correct.

Work around this by assuming that _iff_ the package is the standard lib and
_iff_ we are not cross compiling, then the standard lib is up to date. This
mimicks the pre 0.3.x behaviour and avoids the problem with broken timestamps
in the darwin binary installer.