### PR TITLE
Change `go` binary file lookup for generate & test tools

### DIFF
--- a/cmd/gb/gb_test.go
+++ b/cmd/gb/gb_test.go
@@ -65,7 +65,14 @@ func TestMain(m *testing.M) {
 			os.Exit(2)
 		}
 		testgb = filepath.Join(dir, testgb)
-		out, err := exec.Command(filepath.Join(runtime.GOROOT(), "bin", "go"), "build", "-o", testgb).CombinedOutput()
+
+		goBinary, err := lookupGo()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		out, err := exec.Command(goBinary, "build", "-o", testgb).CombinedOutput()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "building testgb failed: %v\n%s", err, out)
 			os.Exit(2)

--- a/cmd/gb/generate.go
+++ b/cmd/gb/generate.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
@@ -32,10 +31,15 @@ See 'go help generate'.
 			"GOPATH": fmt.Sprintf("%s:%s", ctx.Projectdir(), filepath.Join(ctx.Projectdir(), "vendor")),
 		})
 
-		args = append([]string{filepath.Join(runtime.GOROOT(), "bin", "go"), "generate"}, args...)
+		goBinary, err := lookupGo()
+		if err != nil {
+			return err
+		}
+
+		args = append([]string{goBinary, "generate"}, args...)
 
 		cmd := exec.Cmd{
-			Path: args[0],
+			Path: goBinary,
 			Args: args,
 			Env:  env,
 

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -53,6 +53,14 @@ func fatalf(format string, args ...interface{}) {
 	exit(1)
 }
 
+func lookupGo() (string, error) {
+	path, err := exec.LookPath("go") // filepath.Join(runtime.GOROOT(), "bin", "go")
+	if err != nil {
+		return "", fmt.Errorf("unable to locate `go`: %v", err)
+	}
+	return path, nil
+}
+
 func main() {
 	args := os.Args
 	if len(args) < 2 || args[1] == "-h" {


### PR DESCRIPTION
`filepath.Join(runtime.GOROOT(), "bin", "go")` is not always find the correct location of a `go` binary file

ex.:
- nix os

```
runtime.GOROOT=/nix/store/c4vlrc0bfl5nv85ph9p0hhz2a5h59lkm-go-1.5.1/share/go

% whereis go
go: /nix/store/ys47s890vyrf1vghzhf3vsnnl8k1m6gg-system-path/bin/go

% ls -lah /nix/store/ys47s890vyrf1vghzhf3vsnnl8k1m6gg-system-path/bin/go
/nix/store/ys47s890vyrf1vghzhf3vsnnl8k1m6gg-system-path/bin/go -> /nix/store/c4vlrc0bfl5nv85ph9p0hhz2a5h59lkm-go-1.5.1/bin/go
```
`/nix/store/c4vlrc0bfl5nv85ph9p0hhz2a5h59lkm-go-1.5.1/share/go/bin/go` - is not correct location