### PR TITLE
cmd/gb: fix search path for `go generate`

### DIFF
--- a/cmd/gb/gb_test.go
+++ b/cmd/gb/gb_test.go
@@ -1461,3 +1461,18 @@ func main() {
 	}
 	gb.wantExecutable(gb.path("bin", name), "expected $PROJECT/bin/main")
 }
+
+func TestGbGenerate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skipf("windows doesn't have echo, lol")
+	}
+	gb := T{T: t}
+	defer gb.cleanup()
+	gb.tempDir("src/gentest")
+	gb.tempFile("src/gentest/generate.go", `package gentest
+//go:generate echo $GOPACKAGE $GOFILE
+`)
+	gb.cd(gb.tempdir)
+	gb.run("generate")
+	gb.grepStdout("^gentest generate.go$", "expected $GOPACKAGE $GOFILE")
+}

--- a/cmd/gb/generate.go
+++ b/cmd/gb/generate.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
@@ -32,17 +31,11 @@ See 'go help generate'.
 			"GOPATH": fmt.Sprintf("%s:%s", ctx.Projectdir(), filepath.Join(ctx.Projectdir(), "vendor")),
 		})
 
-		args = append([]string{filepath.Join(runtime.GOROOT(), "bin", "go"), "generate"}, args...)
-
-		cmd := exec.Cmd{
-			Path: args[0],
-			Args: args,
-			Env:  env,
-
-			Stdin:  os.Stdin,
-			Stdout: os.Stdout,
-			Stderr: os.Stderr,
-		}
+		cmd := exec.Command("go", append([]string{"generate"}, args...)...)
+		cmd.Env = env
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
 
 		return cmd.Run()
 	},


### PR DESCRIPTION
Update #521

Also add simple test for go generate.