### PR TITLE
cmd/gb: fix search path for 'gb doc'

### DIFF
--- a/cmd/gb/doc.go
+++ b/cmd/gb/doc.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
@@ -28,17 +27,11 @@ See 'go help doc'.
 			if len(args) == 0 {
 				args = append(args, ".")
 			}
-			args = append([]string{filepath.Join(runtime.GOROOT(), "bin", "godoc")}, args...)
 
-			cmd := exec.Cmd{
-				Path: args[0],
-				Args: args,
-				Env:  env,
-
-				Stdin:  os.Stdin,
-				Stdout: os.Stdout,
-				Stderr: os.Stderr,
-			}
+			cmd := exec.Command("godoc", args...)
+			cmd.Env = env
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
 			return cmd.Run()
 		},
 		SkipParseArgs: true,

--- a/cmd/gb/gb_test.go
+++ b/cmd/gb/gb_test.go
@@ -1476,3 +1476,18 @@ func TestGbGenerate(t *testing.T) {
 	gb.run("generate")
 	gb.grepStdout("^gentest generate.go$", "expected $GOPACKAGE $GOFILE")
 }
+
+func TestGbDoc(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skipf("windows doesn't have echo, lol")
+	}
+	gb := T{T: t}
+	defer gb.cleanup()
+	gb.tempDir("src/doctest")
+	gb.tempFile("src/doctest/doc.go", `// Package doctest tests gb doc
+package doctest
+`)
+	gb.cd(gb.tempdir)
+	gb.run("doc", "doctest")
+	gb.grepStdout("Package doctest tests gb doc$", "expected Package doctest tests gb doc")
+}


### PR DESCRIPTION
Update #521

Also add simple test for gb doc.