### PR TITLE
Allow GOOS and GOARCH control the binary name format

### DIFF
--- a/cmd/gb/gb_test.go
+++ b/cmd/gb/gb_test.go
@@ -1511,24 +1511,28 @@ func main() { println("hello world") }
 `)
 	gb.cd(gb.tempdir)
 	tmpdir := gb.tempDir("tmp")
-
 	gb.setenv("TMP", tmpdir)
+
+	goos := runtime.GOOS
 
 	// scenario 1: GOOS/GOARCH not set
 	name := "p"
+	if goos == "windows" {
+		name += ".exe"
+	}
 	gb.unsetenv("GOOS")
 	gb.unsetenv("GOARCH")
 	gb.run("build")
-	gb.mustExist(gb.path("bin", name))
 	gb.wantExecutable(gb.path("bin", name), "expected $PROJECT/bin/p")
 
 	// scenario 2: GOOS/GOARCH are both set
-	goos := runtime.GOOS
 	name = fmt.Sprintf("p-%s-%s", goos, runtime.GOARCH)
+	if goos == "windows" {
+		name += ".exe"
+	}
 	gb.setenv("GOOS", goos)
 	gb.setenv("GOARCH", runtime.GOARCH)
 	gb.run("build")
-	gb.mustExist(gb.path("bin", name))
 	gb.wantExecutable(gb.path("bin", name), "expected $PROJECT/bin/p-$GOOS-$GOARCH")
 
 	// scenario 3: just GOOS is set

--- a/package.go
+++ b/package.go
@@ -2,6 +2,7 @@ package gb
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -81,8 +82,8 @@ func (pkg *Package) Binfile() string {
 		target = filepath.Join(pkg.Workdir(), filepath.FromSlash(pkg.ImportPath), "_test", binname(pkg))
 	}
 
-	// if this is a cross compile or there are build tags, add ctxString.
-	if pkg.isCrossCompile() {
+	// if this is a cross compile or GOOS/GOARCH are both defined or there are build tags, add ctxString.
+	if pkg.isCrossCompile() || (len(os.Getenv("GOOS")) > 0 && len(os.Getenv("GOARCH")) > 0) {
 		target += "-" + pkg.ctxString()
 	} else if len(pkg.buildtags) > 0 {
 		target += "-" + strings.Join(pkg.buildtags, "-")

--- a/package.go
+++ b/package.go
@@ -83,7 +83,7 @@ func (pkg *Package) Binfile() string {
 	}
 
 	// if this is a cross compile or GOOS/GOARCH are both defined or there are build tags, add ctxString.
-	if pkg.isCrossCompile() || (len(os.Getenv("GOOS")) > 0 && len(os.Getenv("GOARCH")) > 0) {
+	if pkg.isCrossCompile() || (os.Getenv("GOOS") != "" && os.Getenv("GOARCH") != "") {
 		target += "-" + pkg.ctxString()
 	} else if len(pkg.buildtags) > 0 {
 		target += "-" + strings.Join(pkg.buildtags, "-")


### PR DESCRIPTION
Fixes #346 

Especially when cross compiling, it would be useful to have the binary names in a standard format. Here are some samples:

## Default behavior

```
$ tree                                                                                                                                                                
.
└── src
    └── hi
        └── main.go

2 directories, 1 file


$ gb build -f                                                                                                                                                         
hi


$ tree                                                                                                                                                                
.
├── bin
│   └── hi
├── pkg
│   └── linux-amd64
│       └── hi.a
└── src
    └── hi
        └── main.go

5 directories, 3 files
```

## Forcing OS and ARCH
```
$ GOOS=linux GOARCH=amd64 gb build -f                                                                                                                                 
hi


$ tree                                                                                                                                                                
.
├── bin
│   ├── hi
│   └── hi-linux-amd64
├── pkg
│   └── linux-amd64
│       └── hi.a
└── src
    └── hi
        └── main.go

5 directories, 4 files
```

## Cross compiling
```
$ GOOS=darwin GOARCH=amd64 gb build -f                                                                                                                                
errors
unicode/utf8
sync/atomic
math
strconv
runtime
sync
io
syscall
reflect
time
os
fmt
hi

$ tree                                                                                                                                                                
.
├── bin
│   ├── hi
│   ├── hi-darwin-amd64
│   └── hi-linux-amd64
├── pkg
│   ├── darwin-amd64
│   │   ├── errors.a
│   │   ├── fmt.a
│   │   ├── hi.a
│   │   ├── io.a
│   │   ├── math.a
│   │   ├── os.a
│   │   ├── reflect.a
│   │   ├── runtime.a
│   │   ├── strconv.a
│   │   ├── sync
│   │   │   └── atomic.a
│   │   ├── sync.a
│   │   ├── syscall.a
│   │   ├── time.a
│   │   └── unicode
│   │       └── utf8.a
│   └── linux-amd64
│       └── hi.a
└── src
    └── hi
        └── main.go

8 directories, 19 files
```