### PR TITLE
fileutils: add support for copying symlinks to Copypath

### DIFF
--- a/fileutils/fileutils_test.go
+++ b/fileutils/fileutils_test.go
@@ -2,20 +2,28 @@ package fileutils
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 )
 
-func TestCopypathSkipsSymlinks(t *testing.T) {
+func TestCopypathSymlinks(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("no symlinks on windows y'all")
 	}
 	dst := mktemp(t)
 	defer RemoveAll(dst)
-	src := filepath.Join("_testdata", "copyfile", "a")
+	src := filepath.Join("_testdata", "copyfile")
 	if err := Copypath(dst, src); err != nil {
 		t.Fatalf("copypath(%s, %s): %v", dst, src, err)
+	}
+	res, err := os.Readlink(filepath.Join(dst, "a", "rick"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res != "/never/going/to/give/you/up" {
+		t.Fatalf("target == %s, expected /never/going/to/give/you/up", res)
 	}
 }
 


### PR DESCRIPTION
This was removed instead of being special cased in #185, because gb has no
direct need for it (see #184).  However it's useful for other users of the
library.  For example gvt needs to retain test fixtures intact (as vendor/
packages are testable) and needs to support symlink-based packages (since
the go build tool does).

Fixes FiloSottile/gvt#12