### PR TITLE
new package: depfile

### DIFF
--- a/depfile/depfile.go
+++ b/depfile/depfile.go
@@ -1,0 +1,153 @@
+// depfile loads a file of tagged key value pairs.
+package depfile
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// ParseFile parses path into a tagged key value map.
+// See Parse for the syntax of the file.
+func ParseFile(path string) (map[string]map[string]string, error) {
+	r, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("%s:%v", path, err)
+	}
+	defer r.Close()
+	return Parse(r)
+}
+
+// Parse parses the contents of r into a tagged key value map.
+// If successful Parse returns a map[string]map[string]string.
+// The format of the line is
+//
+//     name key=value [key=value]...
+//
+// Elements can be seperated by whitespace (space and tab).
+// Lines that do not begin with a letter or number are ignored. This
+// provides a simple mechanism for commentary
+//
+//     # some comment
+//     github.com/pkg/profile version=0.1.0
+//
+//     ; some other comment
+//     // third kind of comment
+//       lines starting with blank lines are also ignored
+//     github.com/pkg/sftp version=0.2.1
+func Parse(r io.Reader) (map[string]map[string]string, error) {
+	sc := bufio.NewScanner(r)
+	m := make(map[string]map[string]string)
+	var lineno int
+	for sc.Scan() {
+		line := sc.Text()
+		lineno++
+
+		// skip blank line
+		if line == "" {
+			continue
+		}
+
+		// valid lines start with a letter or number everything else is ignored.
+		// we don't need to worry about unicode because import paths are restricted
+		// to the DNS character set, which is a subset of ASCII.
+		if !isLetterOrNumber(line[0]) {
+			continue
+		}
+
+		name, kv, err := parseLine(line)
+		if err != nil {
+			return nil, fmt.Errorf("%d: %v", lineno, err)
+		}
+		m[name] = kv
+	}
+	return m, sc.Err()
+}
+
+func parseLine(line string) (string, map[string]string, error) {
+	args := splitLine(line)
+	name, rest := args[0], args[1:]
+	if len(rest) == 0 {
+		return "", nil, fmt.Errorf("%s: expected key=value pair after name", name)
+	}
+
+	kv, err := parseKeyVal(rest)
+	if err != nil {
+		return "", nil, fmt.Errorf("%s: %v", name, err)
+	}
+	return name, kv, nil
+}
+
+func parseKeyVal(args []string) (map[string]string, error) {
+	m := make(map[string]string)
+	for _, kv := range args {
+		if strings.HasPrefix(kv, "=") {
+			return nil, fmt.Errorf("expected key=value pair, missing key %q", kv)
+		}
+		if strings.HasSuffix(kv, "=") {
+			return nil, fmt.Errorf("expected key=value pair, missing value %q", kv)
+		}
+		args := strings.Split(kv, "=")
+		switch len(args) {
+		case 2:
+			key := args[0]
+			if v, ok := m[key]; ok {
+				return nil, fmt.Errorf("duplicate key=value pair, have \"%s=%s\" got %q", key, v, kv)
+			}
+			m[key] = args[1]
+		default:
+			return nil, fmt.Errorf("expected key=value pair, got %q", kv)
+		}
+	}
+	return m, nil
+}
+
+func isLetterOrNumber(r byte) bool {
+	switch {
+	case r > '0'-1 && r < '9'+1:
+		return true
+	case r > 'a'-1 && r < 'z'+1:
+		return true
+	case r > 'A'-1 && r < 'Z'+1:
+		return true
+	default:
+		return false
+	}
+}
+
+// splitLine is like strings.Split(string, " "), but splits
+// strings by any whitespace characters, discarding them in
+// the process.
+func splitLine(line string) []string {
+	var s []string
+	var start, end int
+	for ; start < len(line); start++ {
+		c := line[start]
+		if !isWhitespace(c) {
+			break
+		}
+	}
+	var ws bool
+	for end = start; end < len(line); end++ {
+		c := line[end]
+		if !isWhitespace(c) {
+			ws = false
+			continue
+		}
+		if ws == true {
+			start++
+			continue
+		}
+		ws = true
+		s = append(s, line[start:end])
+		start = end + 1
+	}
+	if start != end {
+		s = append(s, line[start:end])
+	}
+	return s
+}
+
+func isWhitespace(c byte) bool { return c == ' ' || c == '\t' }

--- a/depfile/depfile_test.go
+++ b/depfile/depfile_test.go
@@ -1,0 +1,192 @@
+package depfile
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseKeyVal(t *testing.T) {
+	tests := []struct {
+		args []string
+		want map[string]string
+		err  error
+	}{{
+		args: []string{},          // handled by Parse
+		want: map[string]string{}, // expected
+	}, {
+		args: []string{"version"},
+		err:  fmt.Errorf("expected key=value pair, got %q", "version"),
+	}, {
+		args: []string{"=9.9.9"},
+		err:  fmt.Errorf("expected key=value pair, missing key %q", "=9.9.9"),
+	}, {
+		args: []string{"version="},
+		err:  fmt.Errorf("expected key=value pair, missing value %q", "version="),
+	}, {
+		args: []string{"version=1.2.3"},
+		want: map[string]string{
+			"version": "1.2.3",
+		},
+	}, {
+		args: []string{"version=1.2.3", "version=2.4.5"},
+		err:  fmt.Errorf("duplicate key=value pair, have \"version=1.2.3\" got %q", "version=2.4.5"),
+	}, {
+		args: []string{"version=1.2.3", "//", "comment"},
+		err:  fmt.Errorf("expected key=value pair, got %q", "//"),
+	}, {
+		args: []string{"vcs=git", "version=1.2.3"},
+		want: map[string]string{
+			"version": "1.2.3",
+			"vcs":     "git",
+		},
+	}}
+
+	for _, tt := range tests {
+		got, err := parseKeyVal(tt.args)
+		if !reflect.DeepEqual(err, tt.err) {
+			t.Errorf("parseKeyVal(%v): got %v, expected %v", tt.args, err, tt.err)
+			continue
+		}
+		if err == nil && !reflect.DeepEqual(tt.want, got) {
+			t.Errorf("parseKeyVal(%v): got %#v, expected %#v", tt.args, got, tt.want)
+		}
+	}
+}
+
+func TestParseLine(t *testing.T) {
+	tests := []struct {
+		line string
+		name string
+		kv   map[string]string
+		err  error
+	}{{
+		line: "a", // no \n, sc.Text removes it
+		err:  fmt.Errorf("a: expected key=value pair after name"),
+	}, {
+		line: "a\ta",
+		err:  fmt.Errorf("a: expected key=value pair, got %q", "a"),
+	}, {
+		line: "a\tversion=7\t  ",
+		name: "a",
+		kv: map[string]string{
+			"version": "7",
+		},
+	}}
+
+	for _, tt := range tests {
+		name, kv, err := parseLine(tt.line)
+		if !reflect.DeepEqual(err, tt.err) {
+			t.Errorf("parseLine(%q): got %v, expected %v", tt.line, err, tt.err)
+			continue
+		}
+		if err == nil && !reflect.DeepEqual(tt.kv, kv) || name != tt.name {
+			t.Errorf("parseLine(%q): got %s %#v, expected %s %#v", tt.line, name, kv, tt.name, tt.kv)
+		}
+	}
+}
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		c    string
+		want map[string]map[string]string
+		err  error
+	}{{
+		c:    "",                                 // empty
+		want: make(map[string]map[string]string), // empty map, not nil
+	}, {
+		c:    "\n",                               // effectively empty
+		want: make(map[string]map[string]string), // empty map, not nil
+	}, {
+		c:   "github.com/pkg/profile", // no \n
+		err: fmt.Errorf("1: github.com/pkg/profile: expected key=value pair after name"),
+	}, {
+		c:   "github.com/pkg/profile\n",
+		err: fmt.Errorf("1: github.com/pkg/profile: expected key=value pair after name"),
+	}, {
+		c: "github.com/pkg/profile version=1.2.3", // no \n
+		want: map[string]map[string]string{
+			"github.com/pkg/profile": {
+				"version": "1.2.3",
+			},
+		},
+	}, {
+		c: "github.com/pkg/profile version=1.2.3\n",
+		want: map[string]map[string]string{
+			"github.com/pkg/profile": {
+				"version": "1.2.3",
+			},
+		},
+	}, {
+		c: "// need to pin version\ngithub.com/pkg/profile version=1.2.3\n",
+		want: map[string]map[string]string{
+			"github.com/pkg/profile": {
+				"version": "1.2.3",
+			},
+		},
+	}, {
+		c: "github.com/pkg/profile version=1.2.3\ngithub.com/pkg/sftp version=0.0.0",
+		want: map[string]map[string]string{
+			"github.com/pkg/profile": {
+				"version": "1.2.3",
+			},
+			"github.com/pkg/sftp": {
+				"version": "0.0.0",
+			},
+		},
+	}, {
+		c: `# some comment
+github.com/pkg/profile version=0.1.0
+
+; some other comment
+// third kind of comment
+ lines starting with blank lines are also ignored
+github.com/pkg/sftp version=0.2.1
+`,
+		want: map[string]map[string]string{
+			"github.com/pkg/profile": {
+				"version": "0.1.0",
+			},
+			"github.com/pkg/sftp": {
+				"version": "0.2.1",
+			},
+		},
+	}}
+
+	for _, tt := range tests {
+		r := strings.NewReader(tt.c)
+		got, err := Parse(r)
+		if !reflect.DeepEqual(err, tt.err) {
+			t.Errorf("Parse(%q): got %v, expected %v", tt.c, err, tt.err)
+			continue
+		}
+		if err == nil && !reflect.DeepEqual(tt.want, got) {
+			t.Errorf("Parse(%q): got %#v, expected %#v", tt.c, got, tt.want)
+		}
+	}
+}
+
+func TestSplitLine(t *testing.T) {
+	tests := []struct {
+		s    string
+		want []string
+	}{
+		{s: "", want: nil},
+		{s: "a", want: []string{"a"}},
+		{s: " a", want: []string{"a"}},
+		{s: "a ", want: []string{"a"}},
+		{s: "a b", want: []string{"a", "b"}},
+		{s: "a b", want: []string{"a", "b"}},
+		{s: "a\tb", want: []string{"a", "b"}},
+		{s: "a \tb", want: []string{"a", "b"}},
+		{s: "\ta \tb ", want: []string{"a", "b"}},
+	}
+
+	for _, tt := range tests {
+		got := splitLine(tt.s)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("splitLine(%q): got %#v, expected %#v", tt.s, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
This package parses an io.Reader consisting of key/value pairs into a `map[string]map[string]string`. The format of the line is

    name key=value [key=value]...

The intention is this package will be used to parse a dependency file, or `depfile`, consisting of lines like this
```
github.com/pkg/profile version=0.1.0
github.com/docker/docker version=1.7.0
```
_note:_ this package does not assign semantic meaning to the contents of the `map[string]map[string]string`.