### PR TITLE
Memoize Package.Imports

### DIFF
--- a/action_test.go
+++ b/action_test.go
@@ -7,10 +7,6 @@ import (
 )
 
 func TestBuildAction(t *testing.T) {
-	actions := func(a ...*Action) []*Action {
-		return a
-	}
-
 	var tests = []struct {
 		pkg    string
 		action *Action
@@ -19,7 +15,7 @@ func TestBuildAction(t *testing.T) {
 		pkg: "a",
 		action: &Action{
 			Name: "build: a",
-			Deps: actions(&Action{Name: "compile: a"}),
+			Deps: []*Action{&Action{Name: "compile: a"}},
 		},
 	}, {
 		pkg: "b",
@@ -74,7 +70,7 @@ func TestBuildAction(t *testing.T) {
 		deleteTasks(got)
 
 		if !reflect.DeepEqual(tt.action, got) {
-			t.Errorf("BuildAction(%v): want %#v, got %#v", tt.pkg, tt.action, got)
+			t.Errorf("BuildAction(%v): want %#+v, got %#+v", tt.pkg, tt.action, got)
 		}
 
 		// double underpants

--- a/build.go
+++ b/build.go
@@ -226,7 +226,7 @@ func logInfoFn(fn func() error, s string) func() error {
 // to build all dependant packages of this package.
 func BuildDependencies(targets map[string]*Action, pkg *Package) ([]*Action, error) {
 	var deps []*Action
-	pkgs := pkg.Imports()
+	pkgs := pkg.Imports
 
 	var extra []string
 	switch {

--- a/context.go
+++ b/context.go
@@ -282,13 +282,10 @@ func (c *Context) loadPackage(stack []string, path string) (*Package, error) {
 	}
 	pop(p.ImportPath)
 
-	pkg := Package{
-		Context: c,
-		Package: p,
-	}
-	pkg.Stale = stale || isStale(&pkg)
-	c.pkgs[p.ImportPath] = &pkg
-	return &pkg, nil
+	pkg := newPackage(c, p)
+	pkg.Stale = stale || isStale(pkg)
+	c.pkgs[p.ImportPath] = pkg
+	return pkg, nil
 }
 
 // importPackage loads a package using the backing set of importers.

--- a/install.go
+++ b/install.go
@@ -99,7 +99,7 @@ func isStale(pkg *Package) bool {
 	}
 
 	// Package is stale if a dependency is newer.
-	for _, p := range pkg.Imports() {
+	for _, p := range pkg.Imports {
 		if p.ImportPath == "C" || p.ImportPath == "unsafe" {
 			continue // ignore stale imports of synthetic packages
 		}


### PR DESCRIPTION
Previously `gb.Package.Imports` was a method which would fetch packages'
from the context package cache matching the import paths of
`gb.Package.Package.Imports`.

This change causes the fetch to happen earlier, which will avoid the
panic happening before the build starts. A followup change can now
change the panic to be an error.