### PR TITLE
Fix package resolution (again)

### DIFF
--- a/cmd/gb/build.go
+++ b/cmd/gb/build.go
@@ -151,9 +151,8 @@ func resolveRootPackages(r Resolver, paths ...string) ([]*gb.Package, error) {
 		if err != nil {
 			return pkgs, fmt.Errorf("failed to resolve import path %q: %v", path, err)
 		}
-		if pkg.SrcRoot != filepath.Join(r.Projectdir(), "src") {
-			fmt.Println("reolvePackage, pkg.SrcRoot", pkg.SrcRoot, "Projectdir", r.Projectdir())
-			// skip package roots that are not from $PROJECT/src
+		if pkg.SrcRoot == filepath.Join(runtime.GOROOT(), "src") {
+			// skip package roots that are not part of this project.
 			// TODO(dfc) should gb return an error here?
 			continue
 		}

--- a/context.go
+++ b/context.go
@@ -431,7 +431,7 @@ func (c *Context) isCrossCompile() bool {
 }
 
 func matchPackages(c *Context, pattern string) ([]string, error) {
-	debug.Debugf("matchPackages: %v %v", c.srcdirs[0].Root, pattern)
+	debug.Debugf("matchPackages: %v", pattern)
 	match := func(string) bool { return true }
 	treeCanMatch := func(string) bool { return true }
 	if pattern != "all" && pattern != "std" {
@@ -441,40 +441,50 @@ func matchPackages(c *Context, pattern string) ([]string, error) {
 
 	var pkgs []string
 
-	src := filepath.Join(c.Projectdir(), "src") + string(filepath.Separator)
-	err := filepath.Walk(src, func(path string, fi os.FileInfo, err error) error {
-		if err != nil || !fi.IsDir() || path == src {
-			return nil
-		}
+	srcs := []string{
+		filepath.Join(c.Projectdir(), "src") + string(filepath.Separator),
+		filepath.Join(c.Projectdir(), "vendor", "src") + string(filepath.Separator),
+	}
+	for _, src := range srcs {
+		err := filepath.Walk(src, func(path string, fi os.FileInfo, err error) error {
+			if err != nil || !fi.IsDir() || path == src {
+				return nil
+			}
 
-		// Avoid .foo, _foo, and testdata directory trees.
-		_, elem := filepath.Split(path)
-		if strings.HasPrefix(elem, ".") || strings.HasPrefix(elem, "_") || elem == "testdata" {
-			return filepath.SkipDir
-		}
+			// Avoid .foo, _foo, and testdata directory trees.
+			elem := fi.Name()
+			if strings.HasPrefix(elem, ".") || strings.HasPrefix(elem, "_") || elem == "testdata" {
+				return filepath.SkipDir
+			}
 
-		name := filepath.ToSlash(path[len(src):])
-		if pattern == "std" && strings.Contains(name, ".") {
-			return filepath.SkipDir
+			name := filepath.ToSlash(path[len(src):])
+			if pattern == "std" && strings.Contains(name, ".") {
+				return filepath.SkipDir
+			}
+			if !treeCanMatch(name) {
+				return filepath.SkipDir
+			}
+			if !match(name) {
+				return nil
+			}
+			_, err = c.importers[1].Import(name)
+			switch err.(type) {
+			case nil:
+				pkgs = append(pkgs, name)
+				return nil
+			case *importer.NoGoError:
+				return nil // skip
+			case *os.PathError:
+				return nil // skip
+			default:
+				return err
+			}
+		})
+		if err != nil {
+			return nil, err
 		}
-		if !treeCanMatch(name) {
-			return filepath.SkipDir
-		}
-		if !match(name) {
-			return nil
-		}
-		_, err = c.importers[1].Import(name)
-		switch err.(type) {
-		case nil:
-			pkgs = append(pkgs, name)
-			return nil
-		case *importer.NoGoError:
-			return nil // skip
-		default:
-			return err
-		}
-	})
-	return pkgs, err
+	}
+	return pkgs, nil
 }
 
 // envForDir returns a copy of the environment


### PR DESCRIPTION
Fixes #505

Refactoring the importer and package root resolution broke a
supported, or promised (I cannot find the link) mode of operation.
See https://github.com/constabulary/gb/pull/548#issuecomment-172972528

This change restores the ability to build packages from $PROJECT/vendor/src
providing they are named explicitly, globbing is not supported.