### PR TITLE
Modify test ```TestGbBuildSubPackageOfCmd``` to show that ```gb generate``` on subdirs of ```cmd```.

### DIFF
--- a/cmd/gb/gb_test.go
+++ b/cmd/gb/gb_test.go
@@ -1430,6 +1430,7 @@ func main() { println("hello world") }
 	gb.cd(gb.tempdir)
 	tmpdir := gb.tempDir("tmp")
 	gb.setenv("TMP", tmpdir)
+	gb.run("generate")
 	gb.run("build")
 	gb.mustBeEmpty(tmpdir)
 	name := "hello"


### PR DESCRIPTION
Problem:
    For subdirectories of ```src/cmd```, running ```gb generate``` fails to
    import:

    ```
    --- FAIL: TestGbBuildSubPackageOfCmd (0.06s)
        gb_test.go:179: running /tmp/testgb347664536/testgb [generate]
        gb_test.go:193: standard error:
        gb_test.go:194: can't load package: package cmd/hello: open /usr/lib/go/src/cmd/hello: no such file or directory
            FATAL: command "generate" failed: exit status 1

        gb_test.go:203: gb [generate] failed unexpectedly: exit status 1
    ```

    It appears that the ```gb generate``` import path only includes
    $GB_GOROOT.

Proposed solution:
    Add $GB_PROJECT_DIR to the import search path for ```gb generate```.

Issue: ##564
Original issue: #492