### PR TITLE
Allow TestCrossCompile to work on ARM* by setting explicit GOARCH too

### DIFF
--- a/cmd/gb/gb_test.go
+++ b/cmd/gb/gb_test.go
@@ -1385,11 +1385,16 @@ func main() { println("hello world") }
 	if runtime.GOOS == goos {
 		goos = "linux"
 	}
+	goarch := "386"
+	if runtime.GOARCH == goarch {
+		goarch = "amd64"
+	}
 	gb.setenv("TMP", tmpdir)
 	gb.setenv("GOOS", goos)
+	gb.setenv("GOARCH", goarch)
 	gb.run("build")
 	gb.mustBeEmpty(tmpdir)
-	name := fmt.Sprintf("p-%s-%s", goos, runtime.GOARCH)
+	name := fmt.Sprintf("p-%s-%s", goos, goarch)
 	if goos == "windows" {
 		name += ".exe"
 	}


### PR DESCRIPTION
Fixes #571

Without this, ARM (armv5, armv7, arm64, and really any `GOARCH` that isn't supported with `GOOS=windows`) fail in the following way:
```
--- FAIL: TestCrossCompile (0.92s)
    gb_test.go:179: running /tmp/testgb935828407/testgb [build]
    gb_test.go:193: standard error:
    gb_test.go:194: # runtime
        netpoll_windows.go:18: undefined: overlapped
        FATAL: command "build" failed: exit status 2

    gb_test.go:203: gb [build] failed unexpectedly: exit status 1
```