### PR TITLE
Update TestRaceMissing to support all the potential error messages of "race not supported"

### DIFF
--- a/cmd/gb/gb_test.go
+++ b/cmd/gb/gb_test.go
@@ -1354,7 +1354,9 @@ func TestRaceMapRW(t *testing.T) {
 	tmpdir := gb.tempDir("tmp")
 	gb.setenv("TMP", tmpdir)
 	gb.runFail("test", "-race")
-	gb.grepStderr(regexp.QuoteMeta(fmt.Sprintf("FATAL: go installation at %s is missing race support", runtime.GOROOT())), "expected missing race support message")
+	raceError1 := fmt.Sprintf("FATAL: go installation at %s is missing race support", runtime.GOROOT())
+	raceError2 := fmt.Sprintf("FATAL: race detector not supported on %s/%s", runtime.GOOS, runtime.GOARCH)
+	gb.grepStderr(regexp.QuoteMeta(raceError1)+"|"+regexp.QuoteMeta(raceError2), "expected missing race support message")
 	gb.mustBeEmpty(tmpdir)
 }
 


### PR DESCRIPTION
See "cmd/gb/main.go" from ~line 138 through ~line 152:

    139: fatalf("race detector not supported on %s/%s", runtime.GOOS, runtime.GOARCH)
    145: fatalf("race detector not supported on %s/%s", runtime.GOOS, runtime.GOARCH)
    151: fatalf("go installation at %s is missing race support. See https://getgb.io/faq/#missing-race-support", runtime.GOROOT())

Fixes #567