### PR TITLE
gb-vendor: fix recursive dependency fetching with -branch

### DIFF
--- a/cmd/gb-vendor/fetch.go
+++ b/cmd/gb-vendor/fetch.go
@@ -110,7 +110,7 @@ func fetch(ctx *gb.Context, path string, recurse bool) error {
 		return err
 	}
 
-	branch, err := wc.Branch()
+	b, err := wc.Branch()
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func fetch(ctx *gb.Context, path string, recurse bool) error {
 		Importpath: path,
 		Repository: repo.URL(),
 		Revision:   rev,
-		Branch:     branch,
+		Branch:     b,
 		Path:       extra,
 	}
 


### PR DESCRIPTION
The branch indication was being carried on to the recursive dependencies
because the global branch variable was getting shadowed before being
cleared.

Reported in FiloSottile/gvt#25