### PR TITLE
Fix problem with private repositories

### DIFF
--- a/cmd/gb-vendor/restore.go
+++ b/cmd/gb-vendor/restore.go
@@ -9,6 +9,7 @@ import (
 	"github.com/constabulary/gb/cmd"
 	"github.com/constabulary/gb/fileutils"
 	"github.com/constabulary/gb/vendor"
+	"net/url"
 )
 
 func addRestoreFlags(fs *flag.FlagSet) {
@@ -40,7 +41,12 @@ func restore(ctx *gb.Context) error {
 
 	for _, dep := range m.Dependencies {
 		fmt.Printf("Getting %s\n", dep.Importpath)
-		repo, _, err := vendor.DeduceRemoteRepo(dep.Importpath, insecure)
+		depPath := dep.Importpath
+		//if user passed ssh as schema during fetch, we must use this schema during restore
+		if url, err := url.Parse(dep.Repository); err==nil && url.Scheme == "ssh" {
+			depPath = dep.Repository
+		}
+		repo, _, err := vendor.DeduceRemoteRepo(depPath, insecure)
 		if err != nil {
 			return fmt.Errorf("Could not process dependency: %s", err)
 		}

--- a/cmd/gb-vendor/update.go
+++ b/cmd/gb-vendor/update.go
@@ -9,6 +9,7 @@ import (
 	"github.com/constabulary/gb/cmd"
 	"github.com/constabulary/gb/fileutils"
 	"github.com/constabulary/gb/vendor"
+"net/url"
 )
 
 var (
@@ -74,8 +75,12 @@ Flags:
 			if err != nil {
 				return fmt.Errorf("dependency could not be deleted from manifest: %v", err)
 			}
-
-			repo, extra, err := vendor.DeduceRemoteRepo(d.Importpath, insecure)
+			depPath := d.Importpath
+			//if user passed ssh as schema during fetch, we must use this schema during update
+			if url, err := url.Parse(d.Repository); err==nil && url.Scheme == "ssh" {
+				depPath = d.Repository
+			}
+			repo, extra, err := vendor.DeduceRemoteRepo(depPath, insecure)
 			if err != nil {
 				return fmt.Errorf("could not determine repository for import %q", d.Importpath)
 			}


### PR DESCRIPTION
If I use my private repository at github as dependency in my project, when I try to do `gb restore` or `gb update`, gb ignores my schema, and by default uses https and this breaks my build process on CI, because git asks to input a username and a password for https and I can't automatically answer on these questions in the build script.
This PR solves the issue