### PR TITLE
Feature: nope mode

### DIFF
--- a/cmd/gb/alldocs.go
+++ b/cmd/gb/alldocs.go
@@ -200,7 +200,7 @@ Test packages
 
 Usage:
 
-        gb test [build flags] -v [packages] [flags for test binary]
+        gb test [build flags] -n -v [packages] [flags for test binary]
 
 Test automates testing the packages named by the import paths.
 
@@ -211,6 +211,8 @@ Flags:
 
         -v
                 print output from test subprocess.
+	-n
+		do not execute test binaries, compile only
 
 
 */

--- a/cmd/gb/gb_test.go
+++ b/cmd/gb/gb_test.go
@@ -821,7 +821,7 @@ func helloworld() {
 }
 
 // test that compiling A in test scope compiles B in regular scope
-func TestTestDepdenantPackage(t *testing.T) {
+func TestTestDependantPackage(t *testing.T) {
 	gb := T{T: t}
 	defer gb.cleanup()
 	gb.tempDir("src")
@@ -866,6 +866,27 @@ func TestTest(t *testing.T) {
 	tmpdir := gb.tempDir("tmp")
 	gb.setenv("TMP", tmpdir)
 	gb.run("test", "pkg1")
+	gb.grepStdout("^pkg1$", `expected "pkg1"`)
+	gb.mustBeEmpty(tmpdir)
+	gb.mustNotExist(filepath.Join(gb.tempdir, "pkg")) // ensure no pkg directory is created
+}
+
+func TestTestPackageNopeMode(t *testing.T) {
+	gb := T{T: t}
+	defer gb.cleanup()
+	gb.tempDir("src")
+	gb.tempDir("src/pkg1")
+	gb.tempFile("src/pkg1/pkg_test.go", `package pkg1
+import "testing"
+
+func TestTest(t *testing.T) {
+	t.Log("hello")
+}
+`)
+	gb.cd(gb.tempdir)
+	tmpdir := gb.tempDir("tmp")
+	gb.setenv("TMP", tmpdir)
+	gb.run("test", "-n", "pkg1")
 	gb.grepStdout("^pkg1$", `expected "pkg1"`)
 	gb.mustBeEmpty(tmpdir)
 	gb.mustNotExist(filepath.Join(gb.tempdir, "pkg")) // ensure no pkg directory is created

--- a/cmd/gb/test.go
+++ b/cmd/gb/test.go
@@ -22,6 +22,7 @@ var (
 	testCoverMode string
 	testCoverPkg  string
 	testVerbose   bool // enable verbose output of test commands
+	testNope      bool // do not execute test binaries, compile and link only
 )
 
 func addTestFlags(fs *flag.FlagSet) {
@@ -30,11 +31,12 @@ func addTestFlags(fs *flag.FlagSet) {
 	fs.StringVar(&testCoverMode, "covermode", "set", "Set covermode: set (default), count, atomic")
 	fs.StringVar(&testCoverPkg, "coverpkg", "", "enable coverage analysis")
 	fs.BoolVar(&testVerbose, "v", false, "enable verbose output of subcommands")
+	fs.BoolVar(&testNope, "n", false, "do not execute test binaries, compile only")
 }
 
 var TestCmd = &cmd.Command{
 	Name:      "test",
-	UsageLine: "test [build flags] -v [packages] [flags for test binary]",
+	UsageLine: "test [build flags] -n -v [packages] [flags for test binary]",
 	Short:     "test packages",
 	Long: `
 Test automates testing the packages named by the import paths.
@@ -46,11 +48,14 @@ Flags:
 
         -v
                 print output from test subprocess.
+	-n
+		do not execute test binaries, compile only
 `,
 	Run: func(ctx *gb.Context, args []string) error {
 		ctx.Force = F
 		ctx.Install = !FF
 		ctx.Verbose = testVerbose
+		ctx.Nope = testNope
 		r := test.TestResolver(ctx)
 
 		// gb build builds packages in dependency order, however

--- a/cmd/gb/testflag.go
+++ b/cmd/gb/testflag.go
@@ -27,6 +27,7 @@ var testFlagDefn = map[string]*testFlagSpec{
 	"r":         {boolVar: true},
 	"f":         {boolVar: true},
 	"F":         {boolVar: true},
+	"n":         {},
 	"P":         {},
 	"ldflags":   {},
 	"gcflags":   {},

--- a/context.go
+++ b/context.go
@@ -40,6 +40,7 @@ type Context struct {
 	Force   bool // force rebuild of packages
 	Install bool // copy packages into $PROJECT/pkg
 	Verbose bool // verbose output
+	Nope    bool // command specfic flag, under test it skips the execute action.
 	race    bool // race detector requested
 
 	gcflags []string // flags passed to the compiler

--- a/test/test.go
+++ b/test/test.go
@@ -188,12 +188,15 @@ func TestPackage(targets map[string]*gb.Action, pkg *gb.Package, flags []string)
 			var output bytes.Buffer
 			err := testmain.Run() // compile and link
 			if err == nil {
-				cmd := exec.Command(testmainpkg.Binfile(), flags...)
-				cmd.Dir = pkg.Dir // tests run in the original source directory
-				cmd.Stdout = &output
-				cmd.Stderr = &output
-				debug.Debugf("%s", cmd.Args)
-				err = cmd.Run() // run test
+				// nope mode means we stop at the compile and link phase.
+				if !pkg.Nope {
+					cmd := exec.Command(testmainpkg.Binfile(), flags...)
+					cmd.Dir = pkg.Dir // tests run in the original source directory
+					cmd.Stdout = &output
+					cmd.Stderr = &output
+					debug.Debugf("%s", cmd.Args)
+					err = cmd.Run() // run test
+				}
 
 				// test binaries can be very large, so always unlink the
 				// binary after the test has run to free up temporary space


### PR DESCRIPTION
Nope mode, a global flag on gb.Context allows gb test to hook `-n` to
skip executing tests, just build and link them.