### PR TITLE
cmd/gb: expand boolean flags when passed to test subprocess

### DIFF
--- a/cmd/gb/testflag.go
+++ b/cmd/gb/testflag.go
@@ -75,6 +75,13 @@ func TestFlags(testArgs []string) []string {
 				}
 				if val.passToTest || val.passToAll {
 					fArg = "-test." + nArg
+					if val.boolVar {
+						// boolean variables can be either -bool, or -bool=true
+						// some code, see issue 605, expects the latter form, so
+						// when present, expand boolean args to their canonical
+						// form.
+						nVal = "true"
+					}
 					if nVal != "" {
 						fArg = fArg + "=" + nVal
 					}

--- a/cmd/gb/testflag_test.go
+++ b/cmd/gb/testflag_test.go
@@ -146,10 +146,10 @@ func TestTestFlags(t *testing.T) {
 	}{
 		{
 			eargs: []string{"-q", "-debug"},
-			targs: []string{"-test.v", "-debug"},
+			targs: []string{"-test.v=true", "-debug"},
 		}, {
 			eargs: []string{"-v", "-debug"},
-			targs: []string{"-test.v", "-debug"},
+			targs: []string{"-test.v=true", "-debug"},
 		}, {
 			eargs: []string{"-bench"},
 			targs: []string{"-test.bench"},
@@ -161,7 +161,7 @@ func TestTestFlags(t *testing.T) {
 			targs: []string{"-test.bench='Test*'"},
 		}, {
 			eargs: []string{"-benchmem"},
-			targs: []string{"-test.benchmem"},
+			targs: []string{"-test.benchmem=true"},
 		}, {
 			eargs: []string{"-benchtime"},
 			targs: []string{"-test.benchtime"},
@@ -188,7 +188,7 @@ func TestTestFlags(t *testing.T) {
 			targs: []string{"-test.memprofile"},
 		}, {
 			eargs: []string{"-short"},
-			targs: []string{"-test.short"},
+			targs: []string{"-test.short=true"},
 		}, {
 			eargs: []string{"-memprofilerate", "1"},
 			targs: []string{"-test.memprofilerate", "1"},


### PR DESCRIPTION
Fixes #605

Goconvey, and probably others, do not parse flags, they just string
match against `os.Args`. Because of this the semantically identical,
`-test.v` and `-test.v=true` are not identical. Fix this by expanding
boolean arguments that are passed to the test subprocess.