### PR TITLE
cmd/gb: restore "all" alias

### DIFF
--- a/cmd/gb/gb_test.go
+++ b/cmd/gb/gb_test.go
@@ -1692,3 +1692,31 @@ func TestFlags(t *testing.T) {
 	gb.mustBeEmpty(tmpdir)
 
 }
+
+// assert the gb build all alias works.
+func TestBuildAll(t *testing.T) {
+	gb := T{T: t}
+	defer gb.cleanup()
+
+	gb.tempFile("src/pkg1/main.go", `package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello")
+}`)
+	gb.tempFile("src/pkg2/main.go", `package main
+
+import "fmt"
+
+func main() {
+        fmt.Println("hello")
+}`)
+
+	gb.cd(filepath.Join(gb.tempdir, "src/pkg2"))
+	tmpdir := gb.tempDir("tmp")
+	gb.run("build", "all")
+	gb.grepStdout("^pkg1$", "expected pkg1")
+	gb.grepStdout("^pkg2$", "expected pkg2")
+	gb.mustBeEmpty(tmpdir)
+}

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -113,6 +113,17 @@ func main() {
 	// arguments into import paths.
 	if !command.SkipParseArgs {
 		srcdir := filepath.Join(ctx.Projectdir(), "src")
+		for _, a := range args {
+			// support the "all" build alias. This used to be handled
+			// in match.ImportPaths, but that's too messy, so if "all"
+			// is present in the args, replace it with "..." and set cwd
+			// to srcdir.
+			if a == "all" {
+				args = []string{"..."}
+				cwd = srcdir
+				break
+			}
+		}
 		args = match.ImportPaths(srcdir, cwd, args)
 	}
 


### PR DESCRIPTION
Restore the "all" alias for matching packages. This was never advertised
but apparently people are using it[1], so hack it back in with a test.

1. https://twitter.com/archeronl/status/745202118332657664