### PR TITLE
feature: add depfile support

### DIFF
--- a/cmd/gb/depfile.go
+++ b/cmd/gb/depfile.go
@@ -1,14 +1,20 @@
 package main
 
 import (
+	"compress/gzip"
 	"crypto/sha1"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd/gb/internal/depfile"
+	"github.com/constabulary/gb/cmd/gb/internal/untar"
 	"github.com/constabulary/gb/internal/debug"
 	"github.com/constabulary/gb/internal/importer"
 	"github.com/pkg/errors"
@@ -32,6 +38,7 @@ func addDepfileDeps(ctx *gb.Context) {
 			continue
 		}
 		root := filepath.Join(cachePath(), hash(prefix, version))
+		downloadIfMissing(root, prefix, version)
 		im := importer.Importer{
 			Context: ctx.Context, // TODO(dfc) this is a hack
 			Root:    root,
@@ -39,6 +46,86 @@ func addDepfileDeps(ctx *gb.Context) {
 		debug.Debugf("Add importer for %q: %v", prefix+" "+version, im.Root)
 		ctx.AddImporter(&im)
 	}
+}
+
+func downloadIfMissing(root, prefix, version string) {
+	dest := filepath.Join(root, "src", filepath.FromSlash(prefix))
+	_, err := os.Stat(dest)
+	if err == nil {
+		// not missing, nothing to do
+		return
+	}
+	if !os.IsNotExist(err) {
+		fatalf("unexpected error stating cache dir: %v", err)
+	}
+	if !strings.HasPrefix(prefix, "github.com") {
+		fatalf("unable to fetch %v", prefix)
+	}
+
+	fmt.Printf("fetching %v (%v)\n", prefix, version)
+
+	rc := fetch(prefix, version)
+	defer rc.Close()
+
+	gzr, err := gzip.NewReader(rc)
+	if err != nil {
+		fatalf("unable to construct gzip reader: %v", err)
+	}
+
+	parent, _ := filepath.Split(dest)
+	mkdirall(parent)
+	tmpdir := tempdir(parent)
+
+	if err := untar.Untar(tmpdir, gzr); err != nil {
+		fatalf("unable to untar: %v", err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	dents, err := ioutil.ReadDir(tmpdir)
+	if err != nil {
+		os.RemoveAll(root)
+		fatalf("cannot read download directory: %v", err)
+	}
+	re := regexp.MustCompile(`\w+-\w+-[a-z0-9]+`)
+	for _, dent := range dents {
+		if re.MatchString(dent.Name()) {
+			if err := os.Rename(filepath.Join(tmpdir, dent.Name()), dest); err != nil {
+				os.RemoveAll(root)
+				fatalf("unable to rename final cache dir: %v", err)
+			}
+			return
+		}
+	}
+	os.RemoveAll(root)
+	fatalf("release directory not found in tarball")
+}
+
+func tempdir(parent string) string {
+	path, err := ioutil.TempDir(parent, "tmp")
+	if err != nil {
+		fatalf("unable to create temporary dir: %v", err)
+	}
+	return path
+}
+
+func mkdirall(path string) {
+	if err := os.MkdirAll(path, 0755); err != nil {
+		fatalf("unable to create directory: %v", err)
+	}
+}
+
+func fetch(prefix, version string) io.ReadCloser {
+	const format = "https://api.github.com/repos/%s/tarball/v%s"
+	prefix = prefix[len("github.com/"):]
+	url := fmt.Sprintf(format, prefix, version)
+	resp, err := http.Get(url)
+	if err != nil {
+		fatalf("failed to fetch %q: %v", url, err)
+	}
+	if resp.StatusCode != 200 {
+		fatalf("failed to fetch %q: expected 200, got %d", url, resp.StatusCode)
+	}
+	return resp.Body
 }
 
 func readDepfile(ctx *gb.Context) (map[string]map[string]string, error) {

--- a/cmd/gb/depfile.go
+++ b/cmd/gb/depfile.go
@@ -57,7 +57,11 @@ func hash(arg string, args ...string) string {
 }
 
 func cachePath() string {
-	return filepath.Join(envOr("HOME", "/tmp"), ".gb", "cache")
+	return filepath.Join(gbhome(), "cache")
+}
+
+func gbhome() string {
+	return envOr("GB_HOME", filepath.Join(envOr("HOME", "/tmp"), ".gb"))
 }
 
 func envOr(key, def string) string {

--- a/cmd/gb/depfile.go
+++ b/cmd/gb/depfile.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/constabulary/gb"
+	"github.com/constabulary/gb/cmd/gb/internal/depfile"
+	"github.com/constabulary/gb/internal/debug"
+	"github.com/constabulary/gb/internal/importer"
+	"github.com/pkg/errors"
+)
+
+// addDepfileDeps inserts into the Context's importer list
+// a set of importers for entries in the depfile.
+func addDepfileDeps(ctx *gb.Context) {
+	df, err := readDepfile(ctx)
+	if err != nil {
+		if !os.IsNotExist(errors.Cause(err)) {
+			fatalf("could not parse depfile: %v", err)
+		}
+		debug.Debugf("no depfile, nothing to do.")
+		return
+	}
+	for prefix, kv := range df {
+		version, ok := kv["version"]
+		if !ok {
+			// TODO(dfc) return error when version key missing
+			continue
+		}
+		root := filepath.Join(cachePath(), hash(prefix, version))
+		im := importer.Importer{
+			Context: ctx.Context, // TODO(dfc) this is a hack
+			Root:    root,
+		}
+		debug.Debugf("Add importer for %q: %v", prefix+" "+version, im.Root)
+		ctx.AddImporter(&im)
+	}
+}
+
+func readDepfile(ctx *gb.Context) (map[string]map[string]string, error) {
+	file := filepath.Join(ctx.Projectdir(), "depfile")
+	debug.Debugf("loading depfile at %q", file)
+	return depfile.ParseFile(file)
+}
+
+func hash(arg string, args ...string) string {
+	h := sha1.New()
+	io.WriteString(h, arg)
+	for _, arg := range args {
+		io.WriteString(h, arg)
+	}
+	return fmt.Sprintf("%x", string(h.Sum(nil)))
+}
+
+func cachePath() string {
+	return filepath.Join(envOr("HOME", "/tmp"), ".gb", "cache")
+}
+
+func envOr(key, def string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		v = def
+	}
+	return v
+}

--- a/cmd/gb/depfile_test.go
+++ b/cmd/gb/depfile_test.go
@@ -1,0 +1,23 @@
+package main_test
+
+import "testing"
+
+func TestMissingDepfile(t *testing.T) {
+	gb := T{T: t}
+	defer gb.cleanup()
+
+	gb.tempDir("src/github.com/user/proj")
+	gb.tempFile("src/github.com/user/proj/main.go", `package main
+
+import "fmt"
+import "github.com/a/b" // would be in depfile
+
+func main() {
+	fmt.Println(b.B)
+}
+`)
+
+	gb.cd(gb.tempdir)
+	gb.runFail("build")
+	gb.grepStderr(`FATAL: command "build" failed:.+import "github.com/a/b": not found`, `import "github.com/a/b": not found`)
+}

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -121,6 +121,9 @@ func main() {
 		atExit = append(atExit, ctx.Destroy)
 	}
 
+	// add additional paths from the depfile
+	addDepfileDeps(ctx)
+
 	if err := command.Run(ctx, args); err != nil {
 		fatalf("command %q failed: %v", name, err)
 	}

--- a/context.go
+++ b/context.go
@@ -29,6 +29,7 @@ type Importer interface {
 // Context represents an execution of one or more Targets inside a Project.
 type Context struct {
 	Project
+	*importer.Context // TODO(dfc) this is a hack
 
 	importers []Importer
 
@@ -165,6 +166,7 @@ func NewContext(p Project, opts ...func(*Context) error) (*Context, error) {
 		ReleaseTags: releaseTags, // from go/build, see gb.go
 		BuildTags:   ctx.buildtags,
 	}
+	ctx.Context = &ic
 
 	ctx.AddImporter(&importer.Importer{
 		Context: &ic,


### PR DESCRIPTION
Updates #536

- Adds support for reading `$PROJECT/depfile`
- Depfile entries are added to import list _after_ `$PROJECT/vendor`

TODO:

- [x] add ENV variable to change `GB_HOME`
- [x] missing entries are downloaded automatically (probably github only
  at the moment).
- [ ] _tests!_