### PR TITLE
remove Project.Srcdirs() method

### DIFF
--- a/cmd/gb/info.go
+++ b/cmd/gb/info.go
@@ -80,7 +80,10 @@ func findenv(env []envvar, name string) string {
 func makeenv(ctx *gb.Context) []envvar {
 	return []envvar{
 		{"GB_PROJECT_DIR", ctx.Projectdir()},
-		{"GB_SRC_PATH", joinlist(ctx.Srcdirs()...)},
+		{"GB_SRC_PATH", joinlist(
+			filepath.Join(ctx.Projectdir(), "src"),
+			filepath.Join(ctx.Projectdir(), "vendor", "src"),
+		)},
 		{"GB_PKG_DIR", ctx.Pkgdir()},
 		{"GB_BIN_SUFFIX", ctx.Suffix()},
 		{"GB_GOROOT", runtime.GOROOT()},

--- a/context.go
+++ b/context.go
@@ -168,15 +168,16 @@ func NewContext(p Project, opts ...func(*Context) error) (*Context, error) {
 	}
 	ctx.Context = &ic
 
-	ctx.AddImporter(&importer.Importer{
-		Context: &ic,
-		Root:    runtime.GOROOT(),
-	})
+	roots := []string{
+		runtime.GOROOT(),
+		ctx.Projectdir(),
+		filepath.Join(ctx.Projectdir(), "vendor"),
+	}
 
-	for _, dir := range p.Srcdirs() {
+	for _, dir := range roots {
 		ctx.AddImporter(&importer.Importer{
 			Context: &ic,
-			Root:    filepath.Dir(dir), // strip off "src"
+			Root:    dir,
 		})
 	}
 

--- a/install_test.go
+++ b/install_test.go
@@ -34,10 +34,7 @@ func TestStale(t *testing.T) {
 	defer os.RemoveAll(root)
 
 	proj := &project{
-		rootdir: root,
-		srcdirs: []string{
-			filepath.Join(getwd(t), "testdata", "src"),
-		},
+		rootdir: filepath.Join(getwd(t), "testdata"),
 	}
 
 	newctx := func() *Context {

--- a/package_test.go
+++ b/package_test.go
@@ -15,9 +15,6 @@ func testProject(t *testing.T) Project {
 	root := filepath.Join(cwd, "testdata")
 	return &project{
 		rootdir: root,
-		srcdirs: []string{
-			filepath.Join(root, "src"),
-		},
 	}
 }
 

--- a/project.go
+++ b/project.go
@@ -21,23 +21,15 @@ type Project interface {
 
 	// Bindir returns the path for compiled programs.
 	Bindir() string
-
-	// Srcdirs returns the path to the source directories.
-	Srcdirs() []string
 }
 
 type project struct {
 	rootdir string
-	srcdirs []string
 }
 
 func NewProject(root string) Project {
 	proj := project{
 		rootdir: root,
-		srcdirs: []string{
-			filepath.Join(root, "src"),
-			filepath.Join(root, "vendor", "src"),
-		},
 	}
 	return &proj
 }
@@ -50,14 +42,6 @@ func (p *project) Pkgdir() string {
 // Projectdir returns the path root of this project.
 func (p *project) Projectdir() string {
 	return p.rootdir
-}
-
-// Srcdirs returns the path to the source directories.
-// The first source directory will always be
-// filepath.Join(Projectdir(), "src")
-// but there may be additional directories.
-func (p *project) Srcdirs() []string {
-	return p.srcdirs
 }
 
 // Bindir returns the path for compiled programs.


### PR DESCRIPTION
The source directories of a gb project never change, they are always
`$PROJECT/src` and `$PROJECT/vendor/src`. This method existed only for the
stale tests which needed to redirect the project's pkg directory to a
temporary location while keeping source in a known location.