### PR TITLE
Refactor importers to not be a slice, but a stack.

### DIFF
--- a/install_test.go
+++ b/install_test.go
@@ -37,6 +37,8 @@ func TestStale(t *testing.T) {
 		rootdir: filepath.Join(getwd(t), "testdata"),
 	}
 
+	defer os.RemoveAll(filepath.Join(proj.Projectdir(), "pkg"))
+
 	newctx := func() *Context {
 		ctx, err := NewContext(proj,
 			GcToolchain(),

--- a/resolver.go
+++ b/resolver.go
@@ -1,0 +1,46 @@
+package gb
+
+import "github.com/constabulary/gb/internal/importer"
+
+type vendorImporter struct {
+	importer.Importer
+}
+
+func (i vendorImporter) Import(path string) (*importer.Package, error) {
+	return i.Importer.Import(path)
+}
+
+type srcImporter struct {
+	Importer
+	im importer.Importer
+}
+
+func (i *srcImporter) Import(path string) (*importer.Package, error) {
+	pkg, err := i.im.Import(path)
+	if err == nil {
+		return pkg, nil
+	}
+
+	// gb expects, when there is a failure to resolve packages that
+	// live in $PROJECT/src that the importer for that directory
+	// will report them.
+
+	pkg, err2 := i.Importer.Import(path)
+	if err2 == nil {
+		return pkg, nil
+	}
+	return nil, err
+}
+
+type gorootImporter struct {
+	Importer
+	im importer.Importer
+}
+
+func (i *gorootImporter) Import(path string) (*importer.Package, error) {
+	pkg, err := i.im.Import(path)
+	if err != nil {
+		return i.Importer.Import(path)
+	}
+	return pkg, nil
+}


### PR DESCRIPTION
When resolving packages they should be done so in an order that matches
the expected search order. First we look in GOROOT, if that misses, then
we look in $PROJECT/src, then if that fails we look in
$PROJECT/vendor/src.

Currently each of these importers has slightly different behaviour, that
will be fixed in a future PR. This current PR makes it possible to slip
another importer, provided by the depfile below the current ones, at the
lowest level.