### PR TITLE
internal/vendor: Add newline to end of file

### DIFF
--- a/internal/vendor/manifest.go
+++ b/internal/vendor/manifest.go
@@ -118,6 +118,11 @@ func writeManifest(w io.Writer, m *Manifest) error {
 	if err != nil {
 		return err
 	}
+	// MarshalIndent does not append a newline after the final closing
+	// curly brace, however many editors will helpfully do this which causes
+	// lots of pointless diffs if you edit the manifest file manually. To work
+	// around this, add a newline after MarshalIndent.
+	buf = append(buf, '\n')
 	_, err = io.Copy(w, bytes.NewReader(buf))
 	return err
 }

--- a/internal/vendor/manifest_test.go
+++ b/internal/vendor/manifest_test.go
@@ -96,7 +96,8 @@ func TestEmptyPathIsNotWritten(t *testing.T) {
 			"branch": "master"
 		}
 	]
-}`
+}
+`
 	got := buf.String()
 	if want != got {
 		t.Fatalf("want: %s, got %s", want, got)


### PR DESCRIPTION
Currently, `git-diff` command suggests "No newline at end of file".

And if edit `vendor/manifest` file uses any editor such as vim, will add newline to the end of file.
So meaningless commit diff will create.
However, this change is adding a new line to all of the manifest files of until now, so also will create meaningless commit diff.

If it normal behavior, please ignore it.