### PR TITLE
Add 'gb version' tool

### DIFF
--- a/cmd/gb/version.go
+++ b/cmd/gb/version.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/constabulary/gb"
+	"github.com/constabulary/gb/cmd"
+)
+
+const version = "0.4.3"
+
+func init() {
+	registerCommand(&cmd.Command{
+		Name:      "version",
+		UsageLine: `version`,
+		Short:     "print the gb version",
+		Long: `
+Version prints the gb version and the Go version, as reported by runtime.Version.
+`,
+		Run:           printVersion,
+		SkipParseArgs: true,
+	})
+}
+
+func printVersion(ctx *gb.Context, args []string) error {
+	fmt.Printf("gb version %s (go version %s)\n", gbversion, runtime.Version())
+	return nil
+}


### PR DESCRIPTION
Run `gb version` to print the version of GB, and the Go version used to compile
the gb binary. This information is useful for debugging and error reporting.

I'm not sure how you release GB - I assume a git tag is involved somewhere
- but that process will need to update to bump the version constant in
`cmd/gb/version.go`. One such tool exists here: github.com/Shyp/bump_version.