### PR TITLE
cmd/gb-vendor: search $GOROOT/src/vendor when resolving recursive deps

### DIFF
--- a/cmd/gb-vendor/fetch.go
+++ b/cmd/gb-vendor/fetch.go
@@ -159,6 +159,7 @@ func fetch(ctx *gb.Context, path string, recurse bool) error {
 			Root, Prefix string
 		}{
 			{filepath.Join(runtime.GOROOT(), "src"), ""},
+			{filepath.Join(runtime.GOROOT(), "src", "vendor"), ""}, // include vendored pkgs from the std library
 			{filepath.Join(ctx.Projectdir(), "src"), ""},
 		}
 		m, err := vendor.ReadManifest(manifestFile(ctx))

--- a/internal/vendor/depset.go
+++ b/internal/vendor/depset.go
@@ -67,6 +67,10 @@ func LoadTree(root string, prefix string) (*Depset, error) {
 	// handle root of the tree
 	fi, err := os.Stat(root)
 	if err != nil {
+		// some paths may not exist, for example $GOROOT/src/vendor on Go < 1.6
+		if os.IsNotExist(err) {
+			return &d, nil
+		}
 		return nil, err
 	}
 	if err := fn(root+string(filepath.Separator), fi); err != nil {


### PR DESCRIPTION
Fixes #635

golang/go#16333 renamed $GOROOT/src/vendor/golang.org to
$GOROOT/src/vendor/golang_org. This solved a nasty problem where code in
GOROOT would shadow any other copy of the net/http2 library, but meant
that gb vendor could no longer resolve the package and try to fetch it
(even if that was pointless).

To solve this, include $GOROOT/src/vendor in the set of search paths so
that golang_org/net/http/... is always found (if present).

I'll add a test for this in the integration test repo.