### PR TITLE
cmd/vendor: ignore invalid XML after <meta> tag

### DIFF
--- a/internal/vendor/discovery.go
+++ b/internal/vendor/discovery.go
@@ -39,9 +39,9 @@ func parseMetaGoImports(r io.Reader) (imports []metaImport, err error) {
 	d.Strict = false
 	var t xml.Token
 	for {
-		t, err = d.Token()
+		t, err = d.RawToken()
 		if err != nil {
-			if err == io.EOF {
+			if err == io.EOF || len(imports) > 0 {
 				err = nil
 			}
 			return


### PR DESCRIPTION
Addressing #642, port two changes from the upstream basis for the "vendor fetch" remote import path parser:
- [Go change 14482](https://go-review.googlesource.com/#/c/14482)  
  _cmd/go: use RawToken to parse remote package metadata_
- [Go change 18051](https://go-review.googlesource.com/#/c/18051)  
  _cmd/go: ignore XML errors after Go <meta> tags_

The first allows "vendor fetch" to accept a server response that matches the "go help importpath" documentation literally, providing solely a "meta" start tag as the entire document. More broadly, it accepts XML documents with improperly nested or even missing elements.

The latter allows "vendor fetch" to accept responses that contain invalid XML encountered after having read at least one "meta" start tag successfully, here the invalidity being due to violations other than element nesting.