### PR TITLE
Rebuild standard library when building with -a and -f

### DIFF
--- a/cmd/gb/build.go
+++ b/cmd/gb/build.go
@@ -105,6 +105,7 @@ For more about where packages and binaries are installed, run 'gb help project'.
 	Run: func(ctx *gb.Context, args []string) error {
 		// TODO(dfc) run should take a *gb.Context not a *gb.Project
 		ctx.Force = F
+		ctx.ForceAll = F && A
 		ctx.Install = !FF
 
 		pkgs, err := resolveRootPackages(ctx, args...)

--- a/context.go
+++ b/context.go
@@ -43,11 +43,12 @@ type Context struct {
 
 	Statistics
 
-	Force   bool // force rebuild of packages
-	Install bool // copy packages into $PROJECT/pkg
-	Verbose bool // verbose output
-	Nope    bool // command specfic flag, under test it skips the execute action.
-	race    bool // race detector requested
+	Force    bool // force rebuild of packages
+	ForceAll bool // force rebuild of all packages, including the standard library
+	Install  bool // copy packages into $PROJECT/pkg
+	Verbose  bool // verbose output
+	Nope     bool // command specfic flag, under test it skips the execute action.
+	race     bool // race detector requested
 
 	gcflags []string // flags passed to the compiler
 	ldflags []string // flags passed to the linker

--- a/install.go
+++ b/install.go
@@ -51,6 +51,10 @@ func isStale(pkg *Package) bool {
 		return false
 	}
 
+	if pkg.ForceAll {
+		return true
+	}
+
 	if !pkg.Standard && pkg.Force {
 		return true
 	}


### PR DESCRIPTION
This is a workaround for #328 which prevents static builds when target and host have the same GOOS and GOARCH. It does this by considering all packages, including the standard library, as stale when running `gb build -a -f`. Previously the `-f` flag ommitted the standard library.