### PR TITLE
Error when multiple paths are passed with --all

### DIFF
--- a/cmd/gb-vendor/delete.go
+++ b/cmd/gb-vendor/delete.go
@@ -36,7 +36,7 @@ Flags:
 	Run: func(ctx *gb.Context, args []string) error {
 		if len(args) != 1 && !deleteAll {
 			return errors.New("delete: import path or --all flag is missing")
-		} else if len(args) == 1 && deleteAll {
+		} else if len(args) >= 1 && deleteAll {
 			return errors.New("delete: you cannot specify path and --all flag at once")
 		}
 


### PR DESCRIPTION
Previously, `gb vendor --all a b` would just delete all vendored
packages.

Closes #646 