### PR TITLE
internal/importer: replace importer.Context with go/build.Context

### DIFF
--- a/context.go
+++ b/context.go
@@ -2,6 +2,7 @@ package gb
 
 import (
 	"fmt"
+	"go/build"
 	"io"
 	"io/ioutil"
 	"os"
@@ -158,7 +159,7 @@ func NewContext(p Project, opts ...func(*Context) error) (*Context, error) {
 	// sort build tags to ensure the ctxSring and Suffix is stable
 	sort.Strings(ctx.buildtags)
 
-	ic := importer.Context{
+	ic := build.Context{
 		GOOS:        ctx.gotargetos,
 		GOARCH:      ctx.gotargetarch,
 		CgoEnabled:  cgoEnabled(ctx.gohostos, ctx.gohostarch, ctx.gotargetos, ctx.gotargetarch),
@@ -412,8 +413,8 @@ func cgoEnabled(gohostos, gohostarch, gotargetos, gotargetarch string) bool {
 	}
 }
 
-func buildImporter(ic *importer.Context, ctx *Context) (Importer, error) {
-	i, err := addDepfileDeps(ic, ctx)
+func buildImporter(bc *build.Context, ctx *Context) (Importer, error) {
+	i, err := addDepfileDeps(bc, ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -422,7 +423,7 @@ func buildImporter(ic *importer.Context, ctx *Context) (Importer, error) {
 	i = &_importer{
 		Importer: i,
 		im: importer.Importer{
-			Context: ic,
+			Context: bc,
 			Root:    filepath.Join(ctx.Projectdir(), "vendor"),
 		},
 	}
@@ -430,7 +431,7 @@ func buildImporter(ic *importer.Context, ctx *Context) (Importer, error) {
 	i = &srcImporter{
 		i,
 		importer.Importer{
-			Context: ic,
+			Context: bc,
 			Root:    ctx.Projectdir(),
 		},
 	}
@@ -438,7 +439,7 @@ func buildImporter(ic *importer.Context, ctx *Context) (Importer, error) {
 	i = &_importer{
 		i,
 		importer.Importer{
-			Context: ic,
+			Context: bc,
 			Root:    runtime.GOROOT(),
 		},
 	}

--- a/depfile.go
+++ b/depfile.go
@@ -4,6 +4,7 @@ import (
 	"compress/gzip"
 	"crypto/sha1"
 	"fmt"
+	"go/build"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -23,7 +24,7 @@ const semverRegex = `^([0-9]+)\.([0-9]+)\.([0-9]+)(?:(\-[0-9A-Za-z-]+(?:\.[0-9A-
 
 // addDepfileDeps inserts into the Context's importer list
 // a set of importers for entries in the depfile.
-func addDepfileDeps(ic *importer.Context, ctx *Context) (Importer, error) {
+func addDepfileDeps(bc *build.Context, ctx *Context) (Importer, error) {
 	i := Importer(new(nullImporter))
 	df, err := readDepfile(ctx)
 	if err != nil {
@@ -58,7 +59,7 @@ func addDepfileDeps(ic *importer.Context, ctx *Context) (Importer, error) {
 			i = &_importer{
 				Importer: i,
 				im: importer.Importer{
-					Context: ic,
+					Context: bc,
 					Root:    root,
 				},
 			}
@@ -85,7 +86,7 @@ func addDepfileDeps(ic *importer.Context, ctx *Context) (Importer, error) {
 			i = &_importer{
 				Importer: i,
 				im: importer.Importer{
-					Context: ic,
+					Context: bc,
 					Root:    root,
 				},
 			}

--- a/internal/importer/build_test.go
+++ b/internal/importer/build_test.go
@@ -5,6 +5,7 @@
 package importer
 
 import (
+	"go/build"
 	"io"
 	"path/filepath"
 	"reflect"
@@ -14,7 +15,7 @@ import (
 
 func TestMatch(t *testing.T) {
 	ctxt := &Importer{
-		Context: &Context{
+		Context: &build.Context{
 			GOOS:   runtime.GOOS,
 			GOARCH: runtime.GOARCH,
 		},
@@ -72,7 +73,7 @@ func TestShouldBuild(t *testing.T) {
 		"func shouldBuild(content []byte)\n"
 	want3 := map[string]bool{}
 
-	ctx := &Importer{Context: &Context{BuildTags: []string{"tag1"}}}
+	ctx := &Importer{Context: &build.Context{BuildTags: []string{"tag1"}}}
 	m := map[string]bool{}
 	if !ctx.shouldBuild([]byte(file1), m) {
 		t.Errorf("shouldBuild(file1) = false, want true")
@@ -90,7 +91,7 @@ func TestShouldBuild(t *testing.T) {
 	}
 
 	m = map[string]bool{}
-	ctx = &Importer{Context: &Context{BuildTags: nil}}
+	ctx = &Importer{Context: &build.Context{BuildTags: nil}}
 	if !ctx.shouldBuild([]byte(file3), m) {
 		t.Errorf("shouldBuild(file3) = false, want true")
 	}
@@ -108,12 +109,12 @@ func (r readNopCloser) Close() error {
 }
 
 var (
-	ctxtP9      = Context{GOARCH: "arm", GOOS: "plan9"}
-	ctxtAndroid = Context{GOARCH: "arm", GOOS: "android"}
+	ctxtP9      = build.Context{GOARCH: "arm", GOOS: "plan9"}
+	ctxtAndroid = build.Context{GOARCH: "arm", GOOS: "android"}
 )
 
 var matchFileTests = []struct {
-	ctxt  Context
+	ctxt  build.Context
 	name  string
 	data  string
 	match bool

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -3,6 +3,7 @@ package importer
 import (
 	"bytes"
 	"fmt"
+	"go/build"
 	"io"
 	"os"
 	pathpkg "path"
@@ -12,24 +13,8 @@ import (
 	"unicode"
 )
 
-type Context struct {
-	GOOS       string // target architecture
-	GOARCH     string // target operating system
-	CgoEnabled bool   // whether cgo can be used
-
-	// The build and release tags specify build constraints
-	// that should be considered satisfied when processing +build lines.
-	// Clients creating a new context may customize BuildTags, which
-	// defaults to empty, but it is usually an error to customize ReleaseTags,
-	// which defaults to the list of Go releases the current release is compatible with.
-	// In addition to the BuildTags and ReleaseTags, build constraints
-	// consider the values of GOARCH and GOOS as satisfied tags.
-	BuildTags   []string
-	ReleaseTags []string
-}
-
 type Importer struct {
-	*Context
+	*build.Context
 	Root string // root directory
 }
 

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -2,6 +2,7 @@ package importer
 
 import (
 	"fmt"
+	"go/build"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -53,7 +54,7 @@ func TestImporter(t *testing.T) {
 		err:      fmt.Errorf("import %q: cannot import absolute path", "/foo"),
 	}, {
 		Importer: Importer{
-			Context: &Context{
+			Context: &build.Context{
 				GOOS:   "linux",
 				GOARCH: "amd64",
 			},
@@ -74,7 +75,7 @@ func TestImporter(t *testing.T) {
 		},
 	}, {
 		Importer: Importer{
-			Context: &Context{
+			Context: &build.Context{
 				GOOS:   "linux",
 				GOARCH: "amd64",
 			},
@@ -84,7 +85,7 @@ func TestImporter(t *testing.T) {
 		err:  &NoGoError{filepath.Join(runtime.GOROOT(), "src", "database")},
 	}, {
 		Importer: Importer{
-			Context: &Context{
+			Context: &build.Context{
 				GOOS:   "linux",
 				GOARCH: "amd64",
 			},
@@ -94,7 +95,7 @@ func TestImporter(t *testing.T) {
 		err:  patherr(filepath.Join(runtime.GOROOT(), "src", "missing")),
 	}, {
 		Importer: Importer{
-			Context: &Context{
+			Context: &build.Context{
 				GOOS:       "linux",
 				GOARCH:     "amd64",
 				CgoEnabled: true,
@@ -104,7 +105,7 @@ func TestImporter(t *testing.T) {
 		path: "net",
 	}, {
 		Importer: Importer{
-			Context: &Context{
+			Context: &build.Context{
 				GOOS:       "linux",
 				GOARCH:     "amd64",
 				CgoEnabled: true,


### PR DESCRIPTION
Part of the plan to replace internal/importer with go/build