### PR TITLE
FIX: limit goroutines in restore command

### DIFF
--- a/cmd/gb-vendor/restore.go
+++ b/cmd/gb-vendor/restore.go
@@ -4,7 +4,9 @@ import (
 	"flag"
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"sync"
+	"sync/atomic"
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
@@ -13,19 +15,24 @@ import (
 	"github.com/pkg/errors"
 )
 
+var threadCount int
+
 func addRestoreFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&insecure, "precaire", false, "allow the use of insecure protocols")
+	fs.IntVar(&threadCount, "threads", runtime.GOMAXPROCS(-1), "thread number limit")
 }
 
 var cmdRestore = &cmd.Command{
 	Name:      "restore",
-	UsageLine: "restore [-precaire]",
+	UsageLine: "restore [-precaire -threads]",
 	Short:     "restore dependencies from the manifest",
 	Long: `Restore vendor dependencies.
 
 Flags:
 	-precaire
 		allow the use of insecure protocols.
+	-threads int
+		thread usage limit (default to cpu number)
 
 `,
 	Run: func(ctx *gb.Context, args []string) error {
@@ -40,41 +47,78 @@ func restore(ctx *gb.Context) error {
 		return errors.Wrap(err, "could not load manifest")
 	}
 
-	errChan := make(chan error, 1)
-	var wg sync.WaitGroup
+	var (
+		counter     int32
+		workerGroup sync.WaitGroup
+		depCount    = len(m.Dependencies)
+		errChan     = make(chan error, threadCount)
+		depChan     = make(chan vendor.Dependency)
+		stopChan    = make(chan struct{})
+		doneChan    = make(chan struct{})
+	)
 
-	wg.Add(len(m.Dependencies))
-	for _, dep := range m.Dependencies {
-		go func(dep vendor.Dependency) {
-			defer wg.Done()
-			fmt.Printf("Getting %s\n", dep.Importpath)
-			repo, _, err := vendor.DeduceRemoteRepo(dep.Importpath, insecure)
-			if err != nil {
-				errChan <- errors.Wrap(err, "could not process dependency")
-				return
-			}
-			wc, err := repo.Checkout("", "", dep.Revision)
-			if err != nil {
-				errChan <- errors.Wrap(err, "could not retrieve dependency")
-				return
-			}
-			dst := filepath.Join(ctx.Projectdir(), "vendor", "src", dep.Importpath)
-			src := filepath.Join(wc.Dir(), dep.Path)
+	fmt.Printf("Need install %d dependencies\n", depCount)
 
-			if err := fileutils.Copypath(dst, src); err != nil {
-				errChan <- err
-				return
-			}
+	workerGroup.Add(threadCount)
+	go func() {
+		defer close(errChan)
+		defer close(doneChan)
+		workerGroup.Wait()
+	}()
 
-			if err := wc.Destroy(); err != nil {
-				errChan <- err
-				return
-			}
-		}(dep)
+	for i := 0; i < threadCount; i++ {
+		go func() {
+			defer workerGroup.Done()
 
+			for dep := range depChan {
+				fmt.Printf("[%v/%d] Getting %s\n", atomic.AddInt32(&counter, 1), depCount, dep.Importpath)
+
+				repo, _, err := vendor.DeduceRemoteRepo(dep.Importpath, insecure)
+				if err != nil {
+					errChan <- errors.Wrap(err, "could not process dependency")
+					return
+				}
+
+				wc, err := repo.Checkout("", "", dep.Revision)
+				if err != nil {
+					errChan <- errors.Wrap(err, "could not retrieve dependency")
+					return
+				}
+
+				dst := filepath.Join(ctx.Projectdir(), "vendor", "src", dep.Importpath)
+				src := filepath.Join(wc.Dir(), dep.Path)
+
+				if err := fileutils.Copypath(dst, src); err != nil {
+					errChan <- err
+					return
+				}
+
+				if err := wc.Destroy(); err != nil {
+					errChan <- err
+					return
+				}
+			}
+		}()
 	}
 
-	wg.Wait()
-	close(errChan)
-	return <-errChan
+	go func() {
+		defer close(depChan)
+
+		for _, dep := range m.Dependencies {
+			select {
+			case <-stopChan:
+				return
+			case depChan <- dep:
+			}
+		}
+	}()
+
+	// wait error
+	err = <-errChan
+	// stop workers after first error
+	close(stopChan)
+	// exit after all goroutines have finished
+	<-doneChan
+
+	return err
 }


### PR DESCRIPTION
Our project have ~120 dependencies and gb creates ~120 parallel requests to github.com.
As result: `curl: (56) SSLRead() return error -36` and `EOF`