### PR TITLE
Remove filepath.Rel code from gc helper.

### DIFF
--- a/build.go
+++ b/build.go
@@ -268,19 +268,6 @@ func BuildDependencies(targets map[string]*Action, pkg *Package) ([]*Action, err
 
 func gc(pkg *Package, gofiles []string) error {
 	t0 := time.Now()
-	for i := range gofiles {
-		if filepath.IsAbs(gofiles[i]) {
-			// terrible hack for cgo files which come with an absolute path
-			continue
-		}
-		fullpath := filepath.Join(pkg.Dir, gofiles[i])
-		path, err := filepath.Rel(pkg.Dir, fullpath)
-		if err == nil {
-			gofiles[i] = path
-		} else {
-			gofiles[i] = fullpath
-		}
-	}
 	err := pkg.tc.Gc(pkg, gofiles)
 	pkg.Record("gc", time.Since(t0))
 	return err


### PR DESCRIPTION
GoFiles in gb come in two kinds.

1. relative to pkg.Dir
2. absolute

In this case the work to absify then relify the path is a noop, which is
further proven by removing it.