### PR TITLE
Add semaphore to `gb vendor restore`

### DIFF
--- a/cmd/gb-vendor/restore.go
+++ b/cmd/gb-vendor/restore.go
@@ -13,26 +13,36 @@ import (
 	"github.com/pkg/errors"
 )
 
+const DefaultJobs = 8
+
 func addRestoreFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&insecure, "precaire", false, "allow the use of insecure protocols")
+	fs.IntVar(&jobs, "jobs", DefaultJobs, "maximum amount of restoration jobs occurring at the same time")
 }
 
-var cmdRestore = &cmd.Command{
-	Name:      "restore",
-	UsageLine: "restore [-precaire]",
-	Short:     "restore dependencies from the manifest",
-	Long: `Restore vendor dependencies.
+var (
+	jobs int
+
+	cmdRestore = &cmd.Command{
+		Name:      "restore",
+		UsageLine: "restore [-precaire]",
+		Short:     "restore dependencies from the manifest",
+		Long: `Restore vendor dependencies.
 
 Flags:
 	-precaire
 		allow the use of insecure protocols.
 
+	-jobs N
+		limit the amount of restoration jobs occurring at the same time.
+
 `,
-	Run: func(ctx *gb.Context, args []string) error {
-		return restore(ctx)
-	},
-	AddFlags: addRestoreFlags,
-}
+		Run: func(ctx *gb.Context, args []string) error {
+			return restore(ctx)
+		},
+		AddFlags: addRestoreFlags,
+	}
+)
 
 func restore(ctx *gb.Context) error {
 	m, err := vendor.ReadManifest(manifestFile(ctx))
@@ -40,13 +50,20 @@ func restore(ctx *gb.Context) error {
 		return errors.Wrap(err, "could not load manifest")
 	}
 
-	errChan := make(chan error, 1)
 	var wg sync.WaitGroup
+
+	errChan := make(chan error, 1)
+	sem := make(chan int, jobs)
 
 	wg.Add(len(m.Dependencies))
 	for _, dep := range m.Dependencies {
+		sem <- 1
 		go func(dep vendor.Dependency) {
-			defer wg.Done()
+			defer func() {
+				wg.Done()
+				<-sem
+			}()
+
 			fmt.Printf("Getting %s\n", dep.Importpath)
 			repo, _, err := vendor.DeduceRemoteRepo(dep.Importpath, insecure)
 			if err != nil {
@@ -71,10 +88,11 @@ func restore(ctx *gb.Context) error {
 				return
 			}
 		}(dep)
-
 	}
 
 	wg.Wait()
+
 	close(errChan)
+	close(sem)
 	return <-errChan
 }


### PR DESCRIPTION
For projects with a lot of dependencies, `gb vendor restore` won't work all the time and fail silently.

This makes pulling them more manageable and more resilient.

Closes #698