### PR TITLE
gb: add testing/internal/testdeps as an extra dependency

### DIFF
--- a/build.go
+++ b/build.go
@@ -239,11 +239,18 @@ func BuildDependencies(targets map[string]*Action, pkg *Package) ([]*Action, err
 			// race binaries have extra implicit depdendenceis.
 			extra = append(extra, "runtime/race")
 		}
-
 	case len(pkg.CgoFiles) > 0 && pkg.ImportPath != "runtime/cgo":
 		// anything that uses cgo has a dependency on runtime/cgo which is
 		// only visible after cgo file generation.
+		// TODO(dfc) what about pkg.Main && pkg.CgoFiles > 0 ??
 		extra = append(extra, "runtime/cgo")
+	}
+	if pkg.TestScope {
+		extra = append(extra, "regexp")
+		if goversion > 1.7 {
+			// since Go 1.8 tests have additional implicit dependencies
+			extra = append(extra, "testing/internal/testdeps")
+		}
 	}
 	for _, i := range extra {
 		p, err := pkg.ResolvePackage(i)

--- a/cmd/gb/gb_test.go
+++ b/cmd/gb/gb_test.go
@@ -1740,3 +1740,30 @@ func TestFoo(t *testing.T) {
 	gb.run("test")
 	gb.mustBeEmpty(tmpdir)
 }
+
+func TestIssue707(t *testing.T) {
+	switch runtime.GOARCH {
+	case "amd64":
+		// good to go
+	default:
+		t.Skipf("test relies on being able to run cross compiled binaries, only supported on amd64")
+	}
+	if strings.HasPrefix(runtime.Version(), "go1.4") {
+		t.Skipf("skipping test on version: %v", runtime.Version())
+	}
+
+	gb := T{T: t}
+	defer gb.cleanup()
+
+	gb.tempFile("src/issue707/issue_test.go", `package t
+
+	import "testing"
+
+	func TestIssue707(t *testing.T) {
+		t.Logf("test passed")
+	}`)
+
+	gb.cd(gb.tempdir)
+	gb.setenv("GOARCH", "386")
+	gb.run("test", "issue707")
+}

--- a/goversion12.go
+++ b/goversion12.go
@@ -1,5 +1,5 @@
 // +build go1.2
-// +build !go1.3,!go1.4,!go1.5,!go1.6
+// +build !go1.3,!go1.4,!go1.5,!go1.6,!go1.7,!go1.8
 
 package gb
 

--- a/goversion13.go
+++ b/goversion13.go
@@ -1,5 +1,5 @@
 // +build go1.3
-// +build !go1.4,!go1.5,!go1.6
+// +build !go1.4,!go1.5,!go1.6,!go1.7,!go1.8
 
 package gb
 

--- a/goversion14.go
+++ b/goversion14.go
@@ -1,5 +1,5 @@
 // +build go1.4
-// +build !go1.5,!go1.6
+// +build !go1.5,!go1.6,!go1.7,!go1.8
 
 package gb
 

--- a/goversion15.go
+++ b/goversion15.go
@@ -1,5 +1,5 @@
 // +build go1.5
-// +build !go1.6
+// +build !go1.6,!go1.7,!go1.8
 
 package gb
 

--- a/goversion16.go
+++ b/goversion16.go
@@ -1,4 +1,5 @@
 // +build go1.6
+// +build !go1.7,!go1.8
 
 package gb
 

--- a/goversion17.go
+++ b/goversion17.go
@@ -1,0 +1,8 @@
+// +build go1.7
+// +build !go1.8
+
+package gb
+
+const (
+	goversion = 1.7
+)

--- a/goversion18.go
+++ b/goversion18.go
@@ -1,0 +1,7 @@
+// +build go1.8
+
+package gb
+
+const (
+	goversion = 1.8
+)


### PR DESCRIPTION
Fixes #707

Go 1.8 split out some parts of the testing package into
testing/internal/testdeps. This is an implicit dependency that needs to
be part of the dep graph to ensure if the runtime is stale, eg, when
cross compiling, it is rebuilt.