### PR TITLE
internal/version: introduce version package for constant

### DIFF
--- a/build.go
+++ b/build.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/constabulary/gb/internal/debug"
 	"github.com/constabulary/gb/internal/fileutils"
+	"github.com/constabulary/gb/internal/version"
 )
 
 // Build builds each of pkgs in succession. If pkg is a command, then the results of build include
@@ -247,7 +248,7 @@ func BuildDependencies(targets map[string]*Action, pkg *Package) ([]*Action, err
 	}
 	if pkg.TestScope {
 		extra = append(extra, "regexp")
-		if goversion > 1.7 {
+		if version.Version > 1.7 {
 			// since Go 1.8 tests have additional implicit dependencies
 			extra = append(extra, "testing/internal/testdeps")
 		}

--- a/cgo.go
+++ b/cgo.go
@@ -12,14 +12,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/constabulary/gb/internal/version"
 	"github.com/pkg/errors"
 )
 
 func cgo(pkg *Package) (*Action, []string, []string, error) {
 	switch {
-	case goversion == 1.4:
+	case version.Version == 1.4:
 		return cgo14(pkg)
-	case goversion > 1.4:
+	case version.Version > 1.4:
 		return cgo15(pkg)
 	default:
 		return nil, nil, nil, errors.Errorf("unsupported Go version: %v", runtime.Version())
@@ -406,12 +407,12 @@ func runcgo1(pkg *Package, cflags, ldflags []string) error {
 
 	args := []string{"-objdir", workdir}
 	switch {
-	case goversion == 1.4:
+	case version.Version == 1.4:
 		args = append(args,
 			"--",
 			"-I", pkg.Dir,
 		)
-	case goversion > 1.4:
+	case version.Version > 1.4:
 		args = append(args,
 			"-importpath", pkg.ImportPath,
 			"--",
@@ -446,12 +447,12 @@ func runcgo2(pkg *Package, dynout, ofile string) error {
 		"-objdir", workdir,
 	}
 	switch {
-	case goversion == 1.4:
+	case version.Version == 1.4:
 		args = append(args,
 			"-dynimport", ofile,
 			"-dynout", dynout,
 		)
-	case goversion > 1.4:
+	case version.Version > 1.4:
 		args = append(args,
 			"-dynpackage", pkg.Name,
 			"-dynimport", ofile,

--- a/cmd/gb/gb_test.go
+++ b/cmd/gb/gb_test.go
@@ -21,6 +21,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/constabulary/gb/internal/version"
 )
 
 var (
@@ -1315,7 +1317,7 @@ func TestTestRace(t *testing.T) {
 	if !canRace {
 		t.Skip("skipping because race detector not supported")
 	}
-	if strings.HasPrefix(runtime.Version(), "go1.4") {
+	if version.Version == 1.4 {
 		t.Skipf("skipping race test as Go version %v incorrectly marks race failures as success", runtime.Version())
 	}
 
@@ -1390,7 +1392,7 @@ func TestNoBuildStdlib(t *testing.T) {
 }
 
 func TestCrossCompile(t *testing.T) {
-	if strings.HasPrefix(runtime.Version(), "go1.4") {
+	if version.Version == 1.4 {
 		t.Skip("skipping cross compile test, not supported on", runtime.Version())
 	}
 	gb := T{T: t}
@@ -1748,7 +1750,7 @@ func TestIssue707(t *testing.T) {
 	default:
 		t.Skipf("test relies on being able to run cross compiled binaries, only supported on amd64")
 	}
-	if strings.HasPrefix(runtime.Version(), "go1.4") {
+	if version.Version == 1.4 {
 		t.Skipf("skipping test on version: %v", runtime.Version())
 	}
 

--- a/goversion18.go
+++ b/goversion18.go
@@ -1,7 +1,0 @@
-// +build go1.8
-
-package gb
-
-const (
-	goversion = 1.8
-)

--- a/internal/version/version12.go
+++ b/internal/version/version12.go
@@ -1,9 +1,9 @@
 // +build go1.2
 // +build !go1.3,!go1.4,!go1.5,!go1.6,!go1.7,!go1.8
 
-package gb
+package version
 
 const (
-	goversion   = 1.2
-	allowVendor = 0
+	Version     = 1.2
+	AllowVendor = 0
 )

--- a/internal/version/version13.go
+++ b/internal/version/version13.go
@@ -1,9 +1,9 @@
 // +build go1.3
 // +build !go1.4,!go1.5,!go1.6,!go1.7,!go1.8
 
-package gb
+package version
 
 const (
-	goversion   = 1.3
-	allowVendor = 0
+	Version     = 1.3
+	AllowVendor = 0
 )

--- a/internal/version/version14.go
+++ b/internal/version/version14.go
@@ -1,9 +1,9 @@
 // +build go1.4
 // +build !go1.5,!go1.6,!go1.7,!go1.8
 
-package gb
+package version
 
 const (
-	goversion   = 1.4
-	allowVendor = 0
+	Version     = 1.4
+	AllowVendor = 0
 )

--- a/internal/version/version15.go
+++ b/internal/version/version15.go
@@ -1,9 +1,9 @@
 // +build go1.5
 // +build !go1.6,!go1.7,!go1.8
 
-package gb
+package version
 
 const (
-	goversion   = 1.5
-	allowVendor = 0
+	Version     = 1.5
+	AllowVendor = 0
 )

--- a/internal/version/version16.go
+++ b/internal/version/version16.go
@@ -1,8 +1,8 @@
 // +build go1.6
 // +build !go1.7,!go1.8
 
-package gb
+package version
 
 const (
-	goversion = 1.6
+	Version = 1.6
 )

--- a/internal/version/version17.go
+++ b/internal/version/version17.go
@@ -1,8 +1,8 @@
 // +build go1.7
 // +build !go1.8
 
-package gb
+package version
 
 const (
-	goversion = 1.7
+	Version = 1.7
 )

--- a/internal/version/version18.go
+++ b/internal/version/version18.go
@@ -1,0 +1,7 @@
+// +build go1.8
+
+package version
+
+const (
+	Version = 1.8
+)

--- a/test/goversion12_test.go
+++ b/test/goversion12_test.go
@@ -1,8 +1,0 @@
-// +build go1.2
-// +build !go1.3,!go1.4,!go1.5,!go1.6,!go1.7
-
-package test
-
-const (
-	goversion = 1.2
-)

--- a/test/goversion13_test.go
+++ b/test/goversion13_test.go
@@ -1,8 +1,0 @@
-// +build go1.3
-// +build !go1.4,!go1.5,!go1.6,!go1.7
-
-package test
-
-const (
-	goversion = 1.3
-)

--- a/test/goversion14_test.go
+++ b/test/goversion14_test.go
@@ -1,8 +1,0 @@
-// +build go1.4
-// +build !go1.5,!go1.6,!go1.7
-
-package test
-
-const (
-	goversion = 1.4
-)

--- a/test/goversion15_test.go
+++ b/test/goversion15_test.go
@@ -1,8 +1,0 @@
-// +build go1.5
-// +build !go1.6
-
-package test
-
-const (
-	goversion = 1.5
-)

--- a/test/goversion16_test.go
+++ b/test/goversion16_test.go
@@ -1,8 +1,0 @@
-// +build go1.6
-// +build !go1.7
-
-package test
-
-const (
-	goversion = 1.6
-)

--- a/test/goversion17_test.go
+++ b/test/goversion17_test.go
@@ -1,7 +1,0 @@
-// +build go1.7
-
-package test
-
-const (
-	goversion = 1.7
-)

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/constabulary/gb"
+	"github.com/constabulary/gb/internal/version"
 )
 
 func TestTest(t *testing.T) {
@@ -76,12 +77,12 @@ func TestTest(t *testing.T) {
 		}}
 
 	for _, tt := range tests {
-		if tt.minversion != 0 && goversion < tt.minversion {
-			t.Logf("skipping test, goversion %f is below mingoversion %f", goversion, tt.minversion)
+		if tt.minversion != 0 && version.Version < tt.minversion {
+			t.Logf("skipping test, goversion %f is below mingoversion %f", version.Version, tt.minversion)
 			continue
 		}
-		if tt.maxversion != 0 && goversion > tt.maxversion {
-			t.Logf("skipping test, goversion %f is above maxgoversion %f", goversion, tt.maxversion)
+		if tt.maxversion != 0 && version.Version > tt.maxversion {
+			t.Logf("skipping test, goversion %f is above maxgoversion %f", version.Version, tt.maxversion)
 			continue
 		}
 		ctx := testContext(t, gb.Ldflags(tt.ldflags...))


### PR DESCRIPTION
Introduce an internal package, internal/version to hold the Go version
constant. This probably won't matter after 0.5 drops support for Go 1.7
and earlier, but this refactoring makes it clear that the constant is
defined in one place, so we can delete it in one place.