### PR TITLE
Add CXXFiles to TestPackage

### DIFF
--- a/test/test.go
+++ b/test/test.go
@@ -97,6 +97,7 @@ func TestPackage(targets map[string]*gb.Action, pkg *gb.Package, flags []string)
 
 		GoFiles:      gofiles,
 		CFiles:       pkg.CFiles,
+		CXXFiles:     pkg.CXXFiles,
 		CgoFiles:     cgofiles,
 		TestGoFiles:  pkg.TestGoFiles,  // passed directly to buildTestMain
 		XTestGoFiles: pkg.XTestGoFiles, // passed directly to buildTestMain


### PR DESCRIPTION
With a project layout like this:
```
.
└── src
    └── proj
        ├── a
        │   ├── a.cpp
        │   ├── a.go
        │   └── a.h
        └── main.go
```
the `test` command will give a linker error when processing the `a` directory. This is because the `.cpp` files are not added to the test package. This change adds the `.cpp` files to the test package. 