### PR TITLE
gb: remove support for Go 1.5 and earlier

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,6 +5,13 @@ shallow_clone: true # for startup speed
 
 environment:
   GOPATH: C:\gopath
+  matrix:
+  - environment:
+    GOVERSION: 1.6.3
+  - environment:
+    GOVERSION: 1.7.5
+  - environment:
+    GOVERSION: 1.8.1
 
 platform:
   - x64

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: go
 go_import_path: github.com/constabulary/gb
 go:
-  - 1.4.x
-  - 1.5.x
   - 1.6.x
   - 1.7.x
   - 1.8.x

--- a/cgo.go
+++ b/cgo.go
@@ -18,9 +18,7 @@ import (
 
 func cgo(pkg *Package) (*Action, []string, []string, error) {
 	switch {
-	case version.Version == 1.4:
-		return cgo14(pkg)
-	case version.Version > 1.4:
+	case version.Version > 1.5:
 		return cgo15(pkg)
 	default:
 		return nil, nil, nil, errors.Errorf("unsupported Go version: %v", runtime.Version())
@@ -407,12 +405,7 @@ func runcgo1(pkg *Package, cflags, ldflags []string) error {
 
 	args := []string{"-objdir", workdir}
 	switch {
-	case version.Version == 1.4:
-		args = append(args,
-			"--",
-			"-I", pkg.Dir,
-		)
-	case version.Version > 1.4:
+	case version.Version > 1.5:
 		args = append(args,
 			"-importpath", pkg.ImportPath,
 			"--",
@@ -447,12 +440,7 @@ func runcgo2(pkg *Package, dynout, ofile string) error {
 		"-objdir", workdir,
 	}
 	switch {
-	case version.Version == 1.4:
-		args = append(args,
-			"-dynimport", ofile,
-			"-dynout", dynout,
-		)
-	case version.Version > 1.4:
+	case version.Version > 1.5:
 		args = append(args,
 			"-dynpackage", pkg.Name,
 			"-dynimport", ofile,

--- a/cmd/gb/gb_test.go
+++ b/cmd/gb/gb_test.go
@@ -1317,10 +1317,6 @@ func TestTestRace(t *testing.T) {
 	if !canRace {
 		t.Skip("skipping because race detector not supported")
 	}
-	if version.Version == 1.4 {
-		t.Skipf("skipping race test as Go version %v incorrectly marks race failures as success", runtime.Version())
-	}
-
 	gb := T{T: t}
 	defer gb.cleanup()
 

--- a/internal/version/version12.go
+++ b/internal/version/version12.go
@@ -1,9 +1,0 @@
-// +build go1.2
-// +build !go1.3,!go1.4,!go1.5,!go1.6,!go1.7,!go1.8
-
-package version
-
-const (
-	Version     = 1.2
-	AllowVendor = 0
-)

--- a/internal/version/version13.go
+++ b/internal/version/version13.go
@@ -1,9 +1,0 @@
-// +build go1.3
-// +build !go1.4,!go1.5,!go1.6,!go1.7,!go1.8
-
-package version
-
-const (
-	Version     = 1.3
-	AllowVendor = 0
-)

--- a/internal/version/version14.go
+++ b/internal/version/version14.go
@@ -1,9 +1,0 @@
-// +build go1.4
-// +build !go1.5,!go1.6,!go1.7,!go1.8
-
-package version
-
-const (
-	Version     = 1.4
-	AllowVendor = 0
-)

--- a/internal/version/version15.go
+++ b/internal/version/version15.go
@@ -1,9 +1,0 @@
-// +build go1.5
-// +build !go1.6,!go1.7,!go1.8
-
-package version
-
-const (
-	Version     = 1.5
-	AllowVendor = 0
-)


### PR DESCRIPTION
The minimum version is Go 1.6 because that is what appengine supports.