### PR TITLE
Treat CGO_ENABLED="0" the same as cross-compiling.

### DIFF
--- a/context.go
+++ b/context.go
@@ -364,7 +364,7 @@ func (s *Statistics) String() string {
 }
 
 func (c *Context) isCrossCompile() bool {
-	return c.gohostos != c.gotargetos || c.gohostarch != c.gotargetarch
+	return c.gohostos != c.gotargetos || c.gohostarch != c.gotargetarch || os.Getenv("CGO_ENABLED") == "0"
 }
 
 // envForDir returns a copy of the environment


### PR DESCRIPTION
This means that explicitly disabling cgo using CGO_ENABLED="0" in
order to get a static binary will work even when the libraries in
GOROOT have been compiled with cgo enabled.

This could be an easy work around for #328