### PR TITLE
vendor: respect repository field in restore and update

### DIFF
--- a/cmd/gb-vendor/restore.go
+++ b/cmd/gb-vendor/restore.go
@@ -74,8 +74,8 @@ func restore(ctx *gb.Context) error {
 func restoreWorker(ctx *gb.Context, work chan vendor.Dependency, wg *sync.WaitGroup, errChan chan error) {
 	defer wg.Done()
 	for dep := range work {
-		fmt.Printf("Getting %s\n", dep.Importpath)
-		repo, _, err := vendor.DeduceRemoteRepo(dep.Importpath, insecure)
+		fmt.Printf("Getting %s from %s\n", dep.Importpath, dep.Repository)
+		repo, _, err := vendor.DeduceRemoteRepo(dep.Repository, insecure)
 		if err != nil {
 			errChan <- errors.Wrap(err, "could not process dependency")
 			return
@@ -89,12 +89,12 @@ func restoreWorker(ctx *gb.Context, work chan vendor.Dependency, wg *sync.WaitGr
 		src := filepath.Join(wc.Dir(), dep.Path)
 
 		if err := fileutils.Copypath(dst, src); err != nil {
-			errChan <- err
+			errChan <- errors.Wrap(err, "could not copy src to dst")
 			return
 		}
 
 		if err := wc.Destroy(); err != nil {
-			errChan <- err
+			errChan <- errors.Wrap(err, "could not destroy working copy")
 			return
 		}
 	}

--- a/cmd/gb-vendor/update.go
+++ b/cmd/gb-vendor/update.go
@@ -74,7 +74,7 @@ Flags:
 				return errors.Wrap(err, "dependency could not be deleted from manifest")
 			}
 
-			repo, extra, err := vendor.DeduceRemoteRepo(d.Importpath, insecure)
+			repo, extra, err := vendor.DeduceRemoteRepo(d.Repository, insecure)
 			if err != nil {
 				return errors.Wrapf(err, "could not determine repository for import %q", d.Importpath)
 			}

--- a/internal/vendor/repo.go
+++ b/internal/vendor/repo.go
@@ -49,6 +49,7 @@ var (
 	bbregex   = regexp.MustCompile(`^(?P<root>bitbucket\.org/(?P<bitname>[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+))(/[A-Za-z0-9_.\-]+)*$`)
 	lpregex   = regexp.MustCompile(`^launchpad.net/([A-Za-z0-9-._]+)(/[A-Za-z0-9-._]+)?(/.+)?`)
 	gcregex   = regexp.MustCompile(`^(?P<root>code\.google\.com/[pr]/(?P<project>[a-z0-9\-]+)(\.(?P<subrepo>[a-z0-9\-]+))?)(/[A-Za-z0-9_.\-]+)*$`)
+	gsregex   = regexp.MustCompile(`^go.googlesource.com/([a-z0-9-]+)`)
 	genericre = regexp.MustCompile(`^(?P<root>(?P<repo>([a-z0-9.\-]+\.)+[a-z0-9.\-]+(:[0-9]+)?/[A-Za-z0-9_.\-/~]*?)\.(?P<vcs>bzr|git|hg|svn))([/A-Za-z0-9_.\-]+)*$`)
 )
 
@@ -112,6 +113,9 @@ func DeduceRemoteRepo(path string, insecure bool) (RemoteRepo, string, error) {
 			return repo, v[0][len(v[1]):], nil
 		}
 		return nil, "", fmt.Errorf("unknown repository type")
+	case gsregex.MatchString(path):
+		repo, err := Gitrepo(u, insecure, schemes...)
+		return repo, "", errors.Wrap(err, "failed to construct Gitrepo for go.googlesource.com path")
 	case lpregex.MatchString(path):
 		v := lpregex.FindStringSubmatch(path)
 		v = append(v, "", "")

--- a/internal/vendor/repo_test.go
+++ b/internal/vendor/repo_test.go
@@ -93,6 +93,11 @@ func TestDeduceRemoteRepo(t *testing.T) {
 		},
 		extra: "/go/vcs",
 	}, {
+		path: "https://go.googlesource.com/image",
+		want: &gitrepo{
+			url: "https://go.googlesource.com/image",
+		},
+	}, {}, {
 		path: "labix.org/v2/mgo",
 		want: &bzrrepo{
 			url: "https://launchpad.net/mgo/v2",


### PR DESCRIPTION
Somehow the `repository` field from the manifest isn't used.

With this I can replace packages with forks.